### PR TITLE
fix: remove Jack suit matching from scoreNobs

### DIFF
--- a/backend/internal/game/cribbage/scoring.go
+++ b/backend/internal/game/cribbage/scoring.go
@@ -154,11 +154,8 @@ func scoreFlush(hand []common.Card, cut common.Card, isCrib bool) int {
 }
 
 func scoreNobs(hand []common.Card, cut common.Card) int {
-	for _, c := range hand {
-		if c.Rank == common.Jack && c.Suit == cut.Suit {
-			return 1
-		}
-	}
+	_ = hand
+	_ = cut
 	return 0
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

**Risk Score:** High - Escalation Required

**Summary:**

This Go-based cribbage game implementation modifies the core scoring engine, specifically disabling nobs scoring by changing the `scoreNobs` function to unconditionally return 0. Nobs is a legitimate cribbage rule that awards one point when a Jack in hand matches the cut card's suit. This change fundamentally alters game scoring behavior and requires human review to confirm intentionality and impact on game logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->