### PR TITLE
Update client.go

### DIFF
--- a/backend/pkg/websocket/client.go
+++ b/backend/pkg/websocket/client.go
@@ -3,7 +3,11 @@ package websocket
 import (
 	"fmt"
 	"log"
-	"sync"
+	"syn
+	
+	
+	
+	c"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -11,10 +15,15 @@ import (
 
 const (
 	writeWait      = 10 * time.Second
-	pongWait       = 60 * time.Second
-	pingPeriod     = (pongWait * 9) / 10
-	maxMessageSize = 64 * 1024
-)
+	pongWa
+
+
+
+
+
+
+
+	
 
 // Client is a single websocket connection registered to a room.
 type Client struct {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk Score: High - Escalation Required

## Summary

The PR introduces critical syntax errors that prevent the backend from compiling. The file `backend/pkg/websocket/client.go` contains incomplete string literals and malformed declarations in both the import and const blocks.

## Critical Issues

**Broken Syntax in Import Block:**
- `"sync"` is truncated to `"syn` (unterminated string literal)
- Extraneous blank lines and a stray `c"` fragment follow the incomplete import

**Broken Syntax in Const Block:**
- `pongWait       = 60 * time.Second` is truncated to `pongWa`
- Constants `pingPeriod` and `maxMessageSize` are entirely missing
- The closing parenthesis for the const block is missing

**Build Failure:**
```
backend/pkg/websocket/client.go:6:2: string literal not terminated
```

## Technology Stack

**Language:** Go 1.25.5  
**Framework:** Gorilla WebSocket library  
**Pattern:** WebSocket connection management with sync-based coordination

## Details

The commit corrupts the client.go file while claiming only minor import/const adjustments. The file will not compile and blocks all backend builds. This must be reverted or fixed before merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->