### PR TITLE
feat: add friends, achievements, chat reactions, and rate limiting [KAN-19] init

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,8 +1,7 @@
 {
   "permissions": {
     "allow": [
-      "Bash(git checkout *)",
-      "Bash(xargs ls -la)"
+      "Bash(git checkout *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout *)",
+      "Bash(xargs ls -la)"
+    ]
+  }
+}

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -15,6 +15,7 @@ import (
 	"fifteen-thirty-one-go/backend/internal/database"
 	"fifteen-thirty-one-go/backend/internal/handlers"
 	"fifteen-thirty-one-go/backend/internal/middleware"
+	"fifteen-thirty-one-go/backend/internal/models"
 	"fifteen-thirty-one-go/backend/internal/tracing"
 	"fifteen-thirty-one-go/backend/pkg/websocket"
 
@@ -41,6 +42,24 @@ func main() {
 			log.Printf("db close error: %v", err)
 		}
 	}()
+
+	// Bootstrap schemas for feature modules that manage their own tables.
+	// These calls are idempotent (CREATE TABLE IF NOT EXISTS) so it's safe to
+	// run them every startup.
+	bootstrapCtx, cancelBootstrap := context.WithTimeout(context.Background(), 10*time.Second)
+	if err := models.EnsureFriendsSchema(bootstrapCtx, db); err != nil {
+		cancelBootstrap()
+		log.Fatalf("friends schema: %v", err)
+	}
+	if err := models.EnsureAchievementsSchema(bootstrapCtx, db); err != nil {
+		cancelBootstrap()
+		log.Fatalf("achievements schema: %v", err)
+	}
+	if err := handlers.EnsureReactionsSchema(bootstrapCtx, db); err != nil {
+		cancelBootstrap()
+		log.Fatalf("reactions schema: %v", err)
+	}
+	cancelBootstrap()
 
 	hubRef := websocket.NewHubRef(websocket.NewHub())
 	go func() {
@@ -86,12 +105,28 @@ func main() {
 	r.GET("/healthz", func(c *gin.Context) { c.JSON(200, gin.H{"ok": true}) })
 
 	api := r.Group("/api")
-	handlers.RegisterAuthRoutes(api, db, cfg)
+
+	// Stricter rate limit on auth: 10 attempts / minute, burst 10. This
+	// dampens credential-stuffing without affecting normal users.
+	authLimiter := middleware.NewLimiter(middleware.Limit{Capacity: 10, RefillEvery: 6 * time.Second}, 5*time.Minute)
+	defer authLimiter.Stop()
+	authGroup := api.Group("")
+	authGroup.Use(authLimiter.Middleware(nil))
+	handlers.RegisterAuthRoutes(authGroup, db, cfg)
 
 	protected := api.Group("")
 	protected.Use(middleware.RequireAuth(cfg))
+
+	// General rate limit on authenticated traffic: 120 req/min, burst 120.
+	apiLimiter := middleware.NewLimiter(middleware.Limit{Capacity: 120, RefillEvery: 500 * time.Millisecond}, 10*time.Minute)
+	defer apiLimiter.Stop()
+	protected.Use(apiLimiter.Middleware(middleware.UserOrIPKey))
+
 	handlers.RegisterLobbyRoutes(protected, db)
 	handlers.RegisterGameRoutes(protected, db)
+	handlers.RegisterFriendsRoutes(protected, db)
+	handlers.RegisterAchievementsRoutes(protected, db)
+	handlers.RegisterChatReactionsRoutes(protected, db)
 
 	// WebSocket endpoint is auth-gated via token query param or Authorization header.
 	r.GET("/ws", handlers.WebSocketHandler(hubRef.Get, db, cfg))

--- a/backend/internal/handlers/achievements.go
+++ b/backend/internal/handlers/achievements.go
@@ -1,0 +1,103 @@
+// Package handlers - achievements.go exposes the achievements module via HTTP.
+package handlers
+
+import (
+	"database/sql"
+	"log"
+	"net/http"
+	"strconv"
+
+	"fifteen-thirty-one-go/backend/internal/models"
+	"fifteen-thirty-one-go/backend/internal/tracing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetCatalogueHandler handles GET /api/achievements/catalogue and returns the
+// static list of all known achievements.
+func GetCatalogueHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		_, span := tracing.StartSpan(c.Request.Context(), "handlers.GetAchievementCatalogue")
+		defer span.End()
+		c.JSON(http.StatusOK, gin.H{"achievements": models.Catalogue})
+	}
+}
+
+// GetMyAchievementsHandler handles GET /api/achievements (current user).
+func GetMyAchievementsHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.GetMyAchievements")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+
+		snap, err := models.ListAchievementsForUser(ctx, db, userID)
+		if err != nil {
+			log.Printf("GetMyAchievementsHandler: user=%d: %v", userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, snap)
+	}
+}
+
+// GetUserAchievementsHandler handles GET /api/users/:user_id/achievements.
+// It is public — anyone can view another user's unlocked achievements.
+func GetUserAchievementsHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.GetUserAchievements")
+		defer span.End()
+
+		// Param name "id" matches the existing /users/:id/* group.
+		uid, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil || uid <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+			return
+		}
+
+		snap, err := models.ListAchievementsForUser(ctx, db, uid)
+		if err != nil {
+			log.Printf("GetUserAchievementsHandler: user=%d: %v", uid, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, snap)
+	}
+}
+
+// EvaluateMyAchievementsHandler handles POST /api/achievements/evaluate. It
+// recomputes the user's achievement set from current stats and returns any
+// newly-unlocked IDs. Intended to be called from the game-finalize path or
+// from a periodic background job; exposed via HTTP for easy debugging.
+func EvaluateMyAchievementsHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.EvaluateMyAchievements")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+
+		newlyUnlocked, err := models.EvaluateAndPersistForUser(ctx, db, userID)
+		if err != nil {
+			log.Printf("EvaluateMyAchievementsHandler: user=%d: %v", userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		// Hydrate the IDs into full catalogue rows for the client.
+		out := make([]models.Achievement, 0, len(newlyUnlocked))
+		for _, id := range newlyUnlocked {
+			if a, ok := models.LookupAchievement(id); ok {
+				out = append(out, a)
+			}
+		}
+		c.JSON(http.StatusOK, gin.H{"newly_unlocked": out})
+	}
+}

--- a/backend/internal/handlers/chat_reactions.go
+++ b/backend/internal/handlers/chat_reactions.go
@@ -1,0 +1,280 @@
+// Package handlers - chat_reactions.go implements emoji reactions on lobby
+// chat messages.
+//
+// Reactions are stored in lobby_message_reactions; each (message_id, user_id,
+// emoji) tuple is unique. Toggling the same emoji removes the row, matching
+// the UX convention of "tap-to-toggle".
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"fifteen-thirty-one-go/backend/internal/tracing"
+	ws "fifteen-thirty-one-go/backend/pkg/websocket"
+
+	"github.com/gin-gonic/gin"
+)
+
+// allowedReactionEmoji is a curated whitelist. We deliberately do not allow
+// arbitrary user-supplied emoji to keep the UI tidy and the index small.
+var allowedReactionEmoji = map[string]struct{}{
+	"👍": {}, "❤️": {}, "😂": {}, "🎉": {}, "🤔": {}, "😢": {}, "🔥": {}, "👏": {},
+}
+
+// ReactionView is the per-emoji rollup returned alongside chat messages.
+type ReactionView struct {
+	Emoji   string  `json:"emoji"`
+	Count   int     `json:"count"`
+	UserIDs []int64 `json:"user_ids"`
+	Reacted bool    `json:"reacted"` // whether the requesting user has reacted
+}
+
+// EnsureReactionsSchema creates the reactions table if missing.
+func EnsureReactionsSchema(ctx context.Context, db *sql.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS lobby_message_reactions (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			message_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			emoji TEXT NOT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(message_id, user_id, emoji)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_reactions_message ON lobby_message_reactions(message_id)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("EnsureReactionsSchema: %w", err)
+		}
+	}
+	return nil
+}
+
+// ToggleReactionHandler handles POST /api/lobbies/:id/chat/:msg_id/react with
+// body {"emoji": "👍"}. Posting the same emoji a second time removes it.
+func ToggleReactionHandler(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.ToggleReaction")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+
+		lobbyID, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil || lobbyID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid lobby id"})
+			return
+		}
+		msgID, err := strconv.ParseInt(c.Param("msg_id"), 10, 64)
+		if err != nil || msgID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid message id"})
+			return
+		}
+
+		var req struct {
+			Emoji string `json:"emoji" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "emoji is required"})
+			return
+		}
+		emoji := strings.TrimSpace(req.Emoji)
+		if !isValidEmoji(emoji) {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported emoji"})
+			return
+		}
+
+		// Authorise: the actor must be in the lobby or a spectator.
+		ok, err = canActInLobby(ctx, db, lobbyID, userID)
+		if err != nil {
+			log.Printf("ToggleReactionHandler: auth check: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		if !ok {
+			c.JSON(http.StatusForbidden, gin.H{"error": "you are not in this lobby"})
+			return
+		}
+
+		// Confirm the message belongs to the lobby (defence in depth).
+		var owningLobby int64
+		err = db.QueryRowContext(ctx, `SELECT lobby_id FROM lobby_messages WHERE id = ?`, msgID).Scan(&owningLobby)
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			c.JSON(http.StatusNotFound, gin.H{"error": "message not found"})
+			return
+		case err != nil:
+			log.Printf("ToggleReactionHandler: lookup message: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		if owningLobby != lobbyID {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "message does not belong to lobby"})
+			return
+		}
+
+		// Toggle: try delete first; if no row was affected, insert.
+		res, err := db.ExecContext(ctx, `
+			DELETE FROM lobby_message_reactions
+			WHERE message_id = ? AND user_id = ? AND emoji = ?
+		`, msgID, userID, emoji)
+		if err != nil {
+			log.Printf("ToggleReactionHandler: delete: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		var added bool
+		if n, _ := res.RowsAffected(); n == 0 {
+			_, err = db.ExecContext(ctx, `
+				INSERT INTO lobby_message_reactions (message_id, user_id, emoji)
+				VALUES (?, ?, ?)
+			`, msgID, userID, emoji)
+			if err != nil {
+				log.Printf("ToggleReactionHandler: insert: %v", err)
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+				return
+			}
+			added = true
+		}
+
+		// Rebuild the reaction rollup for this message and broadcast it.
+		views, err := loadReactionsForMessage(ctx, db, msgID, userID)
+		if err != nil {
+			log.Printf("ToggleReactionHandler: rebuild: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		hub, hubOK := hubProvider()
+		if hubOK && hub != nil {
+			hub.Broadcast(lobbyRoomKey(lobbyID), "lobby:reaction", gin.H{
+				"message_id": msgID,
+				"reactions":  views,
+				"actor":      userID,
+				"emoji":      emoji,
+				"added":      added,
+			})
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"message_id": msgID,
+			"reactions":  views,
+			"added":      added,
+		})
+	}
+}
+
+// GetMessageReactionsHandler handles GET /api/lobbies/:id/chat/:msg_id/reactions.
+func GetMessageReactionsHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.GetMessageReactions")
+		defer span.End()
+
+		userID, _ := userIDFromContext(c)
+		msgID, err := strconv.ParseInt(c.Param("msg_id"), 10, 64)
+		if err != nil || msgID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid message id"})
+			return
+		}
+
+		views, err := loadReactionsForMessage(ctx, db, msgID, userID)
+		if err != nil {
+			log.Printf("GetMessageReactionsHandler: %v", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"reactions": views})
+	}
+}
+
+// isValidEmoji performs the cheap checks. We tolerate variation selectors
+// (e.g. the ❤️ U+FE0F suffix) by allowing strings up to 16 bytes that match
+// the allow-list exactly.
+func isValidEmoji(s string) bool {
+	if s == "" || len(s) > 16 || !utf8.ValidString(s) {
+		return false
+	}
+	_, ok := allowedReactionEmoji[s]
+	return ok
+}
+
+// canActInLobby returns whether userID is either a player or a spectator in
+// the given lobby. Reused by the toggle handler and could be extended for
+// future write-paths.
+func canActInLobby(ctx context.Context, db *sql.DB, lobbyID, userID int64) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `
+		SELECT 1
+		FROM (
+			SELECT gp.user_id
+			FROM game_players gp
+			JOIN games g ON g.id = gp.game_id
+			WHERE g.lobby_id = ? AND gp.user_id = ? AND g.status IN ('waiting', 'in_progress')
+			UNION
+			SELECT ls.user_id FROM lobby_spectators ls
+			WHERE ls.lobby_id = ? AND ls.user_id = ?
+		) AS allowed
+		LIMIT 1
+	`, lobbyID, userID, lobbyID, userID).Scan(&n)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("canActInLobby: %w", err)
+	}
+	return n == 1, nil
+}
+
+// loadReactionsForMessage returns the rollup of reactions on a message. The
+// viewerID is used to populate the Reacted flag; pass 0 for anonymous calls.
+func loadReactionsForMessage(ctx context.Context, db *sql.DB, msgID, viewerID int64) ([]ReactionView, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT emoji, user_id
+		FROM lobby_message_reactions
+		WHERE message_id = ?
+		ORDER BY emoji, created_at ASC
+	`, msgID)
+	if err != nil {
+		return nil, fmt.Errorf("loadReactionsForMessage: query: %w", err)
+	}
+	defer rows.Close()
+
+	byEmoji := make(map[string]*ReactionView, 4)
+	for rows.Next() {
+		var emoji string
+		var uid int64
+		if err := rows.Scan(&emoji, &uid); err != nil {
+			return nil, fmt.Errorf("loadReactionsForMessage: scan: %w", err)
+		}
+		v, ok := byEmoji[emoji]
+		if !ok {
+			v = &ReactionView{Emoji: emoji, UserIDs: make([]int64, 0, 2)}
+			byEmoji[emoji] = v
+		}
+		v.UserIDs = append(v.UserIDs, uid)
+		v.Count++
+		if uid == viewerID {
+			v.Reacted = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("loadReactionsForMessage: iter: %w", err)
+	}
+
+	out := make([]ReactionView, 0, len(byEmoji))
+	for _, v := range byEmoji {
+		out = append(out, *v)
+	}
+	return out, nil
+}

--- a/backend/internal/handlers/friends.go
+++ b/backend/internal/handlers/friends.go
@@ -1,0 +1,276 @@
+// Package handlers - friends.go wires the friends/blocks model into HTTP
+// endpoints. All routes require an authenticated user and use the shared
+// helpers in lobby_helpers.go where applicable.
+package handlers
+
+import (
+	"database/sql"
+	"errors"
+	"log"
+	"net/http"
+	"strconv"
+
+	"fifteen-thirty-one-go/backend/internal/models"
+	"fifteen-thirty-one-go/backend/internal/tracing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// SendFriendRequestHandler handles POST /api/friends/requests with body
+// {"user_id": <int>}. It returns the resulting friendship row.
+func SendFriendRequestHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.SendFriendRequest")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+
+		var req struct {
+			UserID int64 `json:"user_id" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil || req.UserID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
+			return
+		}
+
+		f, err := models.SendFriendRequest(ctx, db, userID, req.UserID)
+		switch {
+		case errors.Is(err, models.ErrSelfFriendship):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "cannot befriend yourself"})
+			return
+		case errors.Is(err, models.ErrAlreadyFriends):
+			c.JSON(http.StatusConflict, gin.H{"error": "already friends"})
+			return
+		case errors.Is(err, models.ErrRequestExists):
+			c.JSON(http.StatusConflict, gin.H{"error": "pending request already exists"})
+			return
+		case errors.Is(err, models.ErrBlocked):
+			c.JSON(http.StatusForbidden, gin.H{"error": "cannot send request — blocked"})
+			return
+		case err != nil:
+			log.Printf("SendFriendRequestHandler: requester=%d other=%d: %v", userID, req.UserID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		c.JSON(http.StatusCreated, gin.H{"request": f})
+	}
+}
+
+// AcceptFriendRequestHandler handles POST /api/friends/requests/:id/accept.
+func AcceptFriendRequestHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.AcceptFriendRequest")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil || id <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request id"})
+			return
+		}
+
+		f, err := models.AcceptFriendRequest(ctx, db, id, userID)
+		switch {
+		case errors.Is(err, models.ErrRequestNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "request not found"})
+			return
+		case errors.Is(err, models.ErrNotAuthorized):
+			c.JSON(http.StatusForbidden, gin.H{"error": "not your request"})
+			return
+		case err != nil:
+			log.Printf("AcceptFriendRequestHandler: id=%d actor=%d: %v", id, userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"friendship": f})
+	}
+}
+
+// DeclineFriendRequestHandler handles POST /api/friends/requests/:id/decline.
+func DeclineFriendRequestHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.DeclineFriendRequest")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		id, err := strconv.ParseInt(c.Param("id"), 10, 64)
+		if err != nil || id <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request id"})
+			return
+		}
+
+		err = models.DeclineFriendRequest(ctx, db, id, userID)
+		switch {
+		case errors.Is(err, models.ErrRequestNotFound):
+			c.JSON(http.StatusNotFound, gin.H{"error": "request not found"})
+			return
+		case errors.Is(err, models.ErrNotAuthorized):
+			c.JSON(http.StatusForbidden, gin.H{"error": "not your request"})
+			return
+		case err != nil:
+			log.Printf("DeclineFriendRequestHandler: id=%d actor=%d: %v", id, userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	}
+}
+
+// RemoveFriendHandler handles DELETE /api/friends/:user_id.
+func RemoveFriendHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.RemoveFriend")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		otherID, err := strconv.ParseInt(c.Param("user_id"), 10, 64)
+		if err != nil || otherID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+			return
+		}
+
+		if err := models.RemoveFriend(ctx, db, userID, otherID); err != nil {
+			log.Printf("RemoveFriendHandler: actor=%d other=%d: %v", userID, otherID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	}
+}
+
+// ListFriendsHandler handles GET /api/friends and returns three lists:
+// accepted friends, incoming pending requests, and outgoing pending requests.
+func ListFriendsHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.ListFriends")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+
+		friends, err := models.ListFriends(ctx, db, userID)
+		if err != nil {
+			log.Printf("ListFriendsHandler: friends user=%d: %v", userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		incoming, err := models.ListIncomingRequests(ctx, db, userID)
+		if err != nil {
+			log.Printf("ListFriendsHandler: incoming user=%d: %v", userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		outgoing, err := models.ListOutgoingRequests(ctx, db, userID)
+		if err != nil {
+			log.Printf("ListFriendsHandler: outgoing user=%d: %v", userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"friends":  friends,
+			"incoming": incoming,
+			"outgoing": outgoing,
+		})
+	}
+}
+
+// BlockUserHandler handles POST /api/friends/blocks with body {"user_id": ...}.
+func BlockUserHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.BlockUser")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+
+		var req struct {
+			UserID int64 `json:"user_id" binding:"required"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil || req.UserID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "user_id is required"})
+			return
+		}
+
+		err := models.BlockUser(ctx, db, userID, req.UserID)
+		switch {
+		case errors.Is(err, models.ErrSelfFriendship):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "cannot block yourself"})
+			return
+		case err != nil:
+			log.Printf("BlockUserHandler: blocker=%d blocked=%d: %v", userID, req.UserID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	}
+}
+
+// UnblockUserHandler handles DELETE /api/friends/blocks/:user_id.
+func UnblockUserHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.UnblockUser")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		otherID, err := strconv.ParseInt(c.Param("user_id"), 10, 64)
+		if err != nil || otherID <= 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+			return
+		}
+		if err := models.UnblockUser(ctx, db, userID, otherID); err != nil {
+			log.Printf("UnblockUserHandler: actor=%d other=%d: %v", userID, otherID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"success": true})
+	}
+}
+
+// ListBlockedHandler handles GET /api/friends/blocks.
+func ListBlockedHandler(db *sql.DB) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx, span := tracing.StartSpan(c.Request.Context(), "handlers.ListBlocked")
+		defer span.End()
+
+		userID, ok := userIDFromContext(c)
+		if !ok || userID <= 0 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		blocks, err := models.ListBlocked(ctx, db, userID)
+		if err != nil {
+			log.Printf("ListBlockedHandler: user=%d: %v", userID, err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"blocked": blocks})
+	}
+}

--- a/backend/internal/handlers/lobby_chat.go
+++ b/backend/internal/handlers/lobby_chat.go
@@ -71,9 +71,7 @@ func SendLobbyChatMessage(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Ha
 
 		ctx := c.Request.Context()
 
-		// Get username
-		var username string
-		err = db.QueryRowContext(ctx, "SELECT username FROM users WHERE id = ?", userID).Scan(&username)
+		username, err := getUsername(ctx, db, userID)
 		if err != nil {
 			wrappedErr := fmt.Errorf("SendLobbyChatMessage: get username (user_id=%d): %w", userID, err)
 			log.Printf("%v", wrappedErr)
@@ -81,21 +79,14 @@ func SendLobbyChatMessage(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Ha
 			return
 		}
 
-		// Verify user is in the lobby
-		var playerCount int
-		err = db.QueryRowContext(ctx, `
-			SELECT COUNT(*)
-			FROM game_players gp
-			JOIN games g ON g.id = gp.game_id
-			WHERE g.lobby_id = ? AND gp.user_id = ? AND g.status IN ('waiting', 'in_progress')
-		`, lobbyID, userID).Scan(&playerCount)
+		isMember, err := isActiveLobbyMember(ctx, db, lobbyID, userID)
 		if err != nil {
 			wrappedErr := fmt.Errorf("SendLobbyChatMessage: check membership (lobby_id=%d user_id=%d): %w", lobbyID, userID, err)
 			log.Printf("%v", wrappedErr)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
-		if playerCount == 0 {
+		if !isMember {
 			c.JSON(http.StatusForbidden, gin.H{"error": "you are not in this lobby"})
 			return
 		}
@@ -132,7 +123,7 @@ func SendLobbyChatMessage(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Ha
 		// Broadcast to lobby room
 		hub, ok := hubProvider()
 		if ok && hub != nil {
-			hub.Broadcast(fmt.Sprintf("lobby:%d", lobbyID), "lobby:chat", chatMsg)
+			hub.Broadcast(lobbyRoomKey(lobbyID), "lobby:chat", chatMsg)
 		}
 
 		c.JSON(http.StatusOK, chatMsg)
@@ -272,9 +263,7 @@ func handleLobbyChatWS(hub *ws.Hub, client *ws.Client, db *sql.DB, payload json.
 		return
 	}
 
-	// Get username
-	var username string
-	err := db.QueryRowContext(ctx, "SELECT username FROM users WHERE id = ?", client.UserID).Scan(&username)
+	username, err := getUsername(ctx, db, client.UserID)
 	if err != nil {
 		wrappedErr := fmt.Errorf("handleLobbyChatWS: get username (user_id=%d): %w", client.UserID, err)
 		log.Printf("%v", wrappedErr)
@@ -285,15 +274,8 @@ func handleLobbyChatWS(hub *ws.Hub, client *ws.Client, db *sql.DB, payload json.
 		return
 	}
 
-	// Verify user is in the lobby
-	var playerCount int
-	err = db.QueryRowContext(ctx, `
-		SELECT COUNT(*)
-		FROM game_players gp
-		JOIN games g ON g.id = gp.game_id
-		WHERE g.lobby_id = ? AND gp.user_id = ? AND g.status IN ('waiting', 'in_progress')
-	`, req.LobbyID, client.UserID).Scan(&playerCount)
-	if err != nil || playerCount == 0 {
+	isMember, err := isActiveLobbyMember(ctx, db, req.LobbyID, client.UserID)
+	if err != nil || !isMember {
 		if err != nil {
 			wrappedErr := fmt.Errorf("handleLobbyChatWS: check membership (lobby_id=%d user_id=%d): %w", req.LobbyID, client.UserID, err)
 			log.Printf("%v", wrappedErr)
@@ -337,7 +319,7 @@ func handleLobbyChatWS(hub *ws.Hub, client *ws.Client, db *sql.DB, payload json.
 	}
 
 	// Broadcast to lobby room
-	hub.Broadcast(fmt.Sprintf("lobby:%d", req.LobbyID), "lobby:chat", chatMsg)
+	hub.Broadcast(lobbyRoomKey(req.LobbyID), "lobby:chat", chatMsg)
 }
 
 // SendSystemMessage inserts a system message into the lobby chat and broadcasts it via WebSocket if hub is provided.
@@ -371,7 +353,7 @@ func SendSystemMessage(ctx context.Context, db *sql.DB, hub *ws.Hub, lobbyID int
 	}
 
 	if hub != nil {
-		hub.Broadcast(fmt.Sprintf("lobby:%d", lobbyID), "lobby:chat", chatMsg)
+		hub.Broadcast(lobbyRoomKey(lobbyID), "lobby:chat", chatMsg)
 	}
 
 	return nil

--- a/backend/internal/handlers/lobby_helpers.go
+++ b/backend/internal/handlers/lobby_helpers.go
@@ -1,0 +1,46 @@
+package handlers
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+)
+
+// lobbyRoomKey returns the websocket room name for a given lobby.
+// Centralised so the format ("lobby:<id>") cannot drift between handlers and
+// so callers avoid repeated fmt.Sprintf allocations on hot broadcast paths.
+func lobbyRoomKey(lobbyID int64) string {
+	return "lobby:" + strconv.FormatInt(lobbyID, 10)
+}
+
+// getUsername looks up a user's username by id. Returns sql.ErrNoRows if the
+// user does not exist.
+func getUsername(ctx context.Context, db *sql.DB, userID int64) (string, error) {
+	var username string
+	err := db.QueryRowContext(ctx, "SELECT username FROM users WHERE id = ?", userID).Scan(&username)
+	return username, err
+}
+
+// getUserDisplay looks up a user's username and avatar URL by id.
+func getUserDisplay(ctx context.Context, db *sql.DB, userID int64) (string, sql.NullString, error) {
+	var username string
+	var avatar sql.NullString
+	err := db.QueryRowContext(ctx, "SELECT username, avatar_url FROM users WHERE id = ?", userID).Scan(&username, &avatar)
+	return username, avatar, err
+}
+
+// isActiveLobbyMember reports whether userID is a player in an active
+// (waiting or in_progress) game within the given lobby.
+func isActiveLobbyMember(ctx context.Context, db *sql.DB, lobbyID, userID int64) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*)
+		FROM game_players gp
+		JOIN games g ON g.id = gp.game_id
+		WHERE g.lobby_id = ? AND gp.user_id = ? AND g.status IN ('waiting', 'in_progress')
+	`, lobbyID, userID).Scan(&n)
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
+}

--- a/backend/internal/handlers/routes.go
+++ b/backend/internal/handlers/routes.go
@@ -64,3 +64,31 @@ func RegisterGameRoutes(rg *gin.RouterGroup, db *sql.DB) {
 	rg.GET("/scoreboard/:userId", UserStatsHandler(db))
 	rg.GET("/leaderboard", LeaderboardHandler(db))
 }
+
+// RegisterFriendsRoutes wires the friends/blocks endpoints. All routes
+// require authentication (handlers reject unauthenticated requests).
+func RegisterFriendsRoutes(rg *gin.RouterGroup, db *sql.DB) {
+	rg.GET("/friends", ListFriendsHandler(db))
+	rg.POST("/friends/requests", SendFriendRequestHandler(db))
+	rg.POST("/friends/requests/:id/accept", AcceptFriendRequestHandler(db))
+	rg.POST("/friends/requests/:id/decline", DeclineFriendRequestHandler(db))
+	rg.DELETE("/friends/:user_id", RemoveFriendHandler(db))
+
+	rg.GET("/friends/blocks", ListBlockedHandler(db))
+	rg.POST("/friends/blocks", BlockUserHandler(db))
+	rg.DELETE("/friends/blocks/:user_id", UnblockUserHandler(db))
+}
+
+// RegisterAchievementsRoutes wires the achievements endpoints.
+func RegisterAchievementsRoutes(rg *gin.RouterGroup, db *sql.DB) {
+	rg.GET("/achievements/catalogue", GetCatalogueHandler())
+	rg.GET("/achievements", GetMyAchievementsHandler(db))
+	rg.POST("/achievements/evaluate", EvaluateMyAchievementsHandler(db))
+	rg.GET("/users/:id/achievements", GetUserAchievementsHandler(db))
+}
+
+// RegisterChatReactionsRoutes wires emoji reactions for lobby chat messages.
+func RegisterChatReactionsRoutes(rg *gin.RouterGroup, db *sql.DB) {
+	rg.POST("/lobbies/:id/chat/:msg_id/react", ToggleReactionHandler(db, getHubProvider))
+	rg.GET("/lobbies/:id/chat/:msg_id/reactions", GetMessageReactionsHandler(db))
+}

--- a/backend/internal/handlers/spectator.go
+++ b/backend/internal/handlers/spectator.go
@@ -82,28 +82,19 @@ func JoinAsSpectator(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Handler
 		}
 
 		// Check if user is already a player in this lobby
-		var playerCount int
-		err = db.QueryRowContext(ctx, `
-			SELECT COUNT(*)
-			FROM game_players gp
-			JOIN games g ON g.id = gp.game_id
-			WHERE g.lobby_id = ? AND gp.user_id = ? AND g.status IN ('waiting', 'in_progress')
-		`, lobbyID, userID).Scan(&playerCount)
+		isMember, err := isActiveLobbyMember(ctx, db, lobbyID, userID)
 		if err != nil {
 			wrappedErr := fmt.Errorf("JoinAsSpectator: checking player status (lobby_id=%d user_id=%d): %w", lobbyID, userID, err)
 			log.Printf("%v", wrappedErr)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "internal server error"})
 			return
 		}
-		if playerCount > 0 {
+		if isMember {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "you are already a player in this lobby"})
 			return
 		}
 
-		// Get username
-		var username string
-		var avatarURL sql.NullString
-		err = db.QueryRowContext(ctx, "SELECT username, avatar_url FROM users WHERE id = ?", userID).Scan(&username, &avatarURL)
+		username, avatarURL, err := getUserDisplay(ctx, db, userID)
 		if err != nil {
 			wrappedErr := fmt.Errorf("JoinAsSpectator: get user info (user_id=%d): %w", userID, err)
 			log.Printf("%v", wrappedErr)
@@ -146,7 +137,8 @@ func JoinAsSpectator(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Handler
 		// Broadcast spectator joined event
 		hub, ok := hubProvider()
 		if ok && hub != nil {
-			hub.Broadcast(fmt.Sprintf("lobby:%d", lobbyID), "lobby:spectator_joined", spectator)
+			room := lobbyRoomKey(lobbyID)
+			hub.Broadcast(room, "lobby:spectator_joined", spectator)
 
 			// Send system message
 			_ = SendSystemMessage(ctx, db, hub, lobbyID, fmt.Sprintf("%s is now spectating", username), "join")
@@ -186,8 +178,7 @@ func LeaveAsSpectator(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Handle
 		ctx := c.Request.Context()
 
 		// Get username before deleting
-		var username string
-		err = db.QueryRowContext(ctx, "SELECT username FROM users WHERE id = ?", userID).Scan(&username)
+		username, err := getUsername(ctx, db, userID)
 		if err != nil {
 			wrappedErr := fmt.Errorf("LeaveAsSpectator: get username (user_id=%d): %w", userID, err)
 			log.Printf("%v", wrappedErr)
@@ -216,7 +207,8 @@ func LeaveAsSpectator(db *sql.DB, hubProvider func() (*ws.Hub, bool)) gin.Handle
 		// Broadcast spectator left event
 		hub, ok := hubProvider()
 		if ok && hub != nil {
-			hub.Broadcast(fmt.Sprintf("lobby:%d", lobbyID), "lobby:spectator_left", map[string]any{
+			room := lobbyRoomKey(lobbyID)
+			hub.Broadcast(room, "lobby:spectator_left", map[string]any{
 				"user_id":  userID,
 				"username": username,
 			})

--- a/backend/internal/middleware/ratelimit.go
+++ b/backend/internal/middleware/ratelimit.go
@@ -1,0 +1,223 @@
+// Package middleware provides Gin middleware components used by the HTTP
+// server. The rate limiter implemented here is an in-memory, per-key token
+// bucket with periodic GC. It is intentionally dependency-free so it can be
+// dropped into any handler chain without external state.
+package middleware
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Limit defines the token-bucket parameters for a single key. Capacity is the
+// maximum burst; RefillEvery is how often a single token is added (so the
+// sustained rate is 1 token / RefillEvery).
+type Limit struct {
+	Capacity    int
+	RefillEvery time.Duration
+}
+
+// KeyFunc derives a stable key from a request. Implementations should return
+// an empty string to indicate the request is not subject to rate limiting
+// (e.g. health checks).
+type KeyFunc func(c *gin.Context) string
+
+// bucket is the internal mutable state for a single rate-limit key.
+type bucket struct {
+	tokens     int
+	lastRefill time.Time
+}
+
+// Limiter is a goroutine-safe in-memory rate limiter. Use NewLimiter and pair
+// with Middleware. A single Limiter can be shared across multiple routes; if
+// you want different policies, instantiate one per policy.
+type Limiter struct {
+	mu       sync.Mutex
+	buckets  map[string]*bucket
+	limit    Limit
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewLimiter creates a Limiter with the given policy and starts a background
+// goroutine that evicts stale buckets every gcInterval. Callers should invoke
+// Stop when the limiter is no longer needed (e.g. on graceful shutdown) to
+// avoid leaking the GC goroutine.
+func NewLimiter(limit Limit, gcInterval time.Duration) *Limiter {
+	if limit.Capacity <= 0 {
+		limit.Capacity = 30
+	}
+	if limit.RefillEvery <= 0 {
+		limit.RefillEvery = time.Second
+	}
+	if gcInterval <= 0 {
+		gcInterval = 5 * time.Minute
+	}
+	l := &Limiter{
+		buckets: make(map[string]*bucket, 256),
+		limit:   limit,
+		stop:    make(chan struct{}),
+	}
+	go l.runGC(gcInterval)
+	return l
+}
+
+// Stop terminates the GC goroutine. Safe to call multiple times.
+func (l *Limiter) Stop() {
+	l.stopOnce.Do(func() { close(l.stop) })
+}
+
+func (l *Limiter) runGC(interval time.Duration) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-l.stop:
+			return
+		case now := <-t.C:
+			l.gc(now)
+		}
+	}
+}
+
+// gc removes buckets that have been idle for at least 4x the refill window.
+// The threshold is heuristic: long enough that an active client is unlikely
+// to be evicted between requests, short enough that abandoned keys do not
+// accumulate.
+func (l *Limiter) gc(now time.Time) {
+	threshold := 4 * l.limit.RefillEvery * time.Duration(l.limit.Capacity)
+	if threshold < time.Minute {
+		threshold = time.Minute
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for k, b := range l.buckets {
+		if now.Sub(b.lastRefill) > threshold && b.tokens >= l.limit.Capacity {
+			delete(l.buckets, k)
+		}
+	}
+}
+
+// take attempts to consume one token for key. It returns true if a token was
+// available, along with the number of tokens remaining and the time at which
+// the next token will be available (zero if a token is available now).
+func (l *Limiter) take(key string, now time.Time) (allowed bool, remaining int, retryAfter time.Duration) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	b, ok := l.buckets[key]
+	if !ok {
+		b = &bucket{tokens: l.limit.Capacity, lastRefill: now}
+		l.buckets[key] = b
+	}
+
+	// Refill based on elapsed time.
+	elapsed := now.Sub(b.lastRefill)
+	if elapsed > 0 && l.limit.RefillEvery > 0 {
+		add := int(elapsed / l.limit.RefillEvery)
+		if add > 0 {
+			b.tokens += add
+			if b.tokens > l.limit.Capacity {
+				b.tokens = l.limit.Capacity
+			}
+			b.lastRefill = b.lastRefill.Add(time.Duration(add) * l.limit.RefillEvery)
+		}
+	}
+
+	if b.tokens <= 0 {
+		// No token available; report when the next one arrives.
+		retryAfter = l.limit.RefillEvery - now.Sub(b.lastRefill)
+		if retryAfter < 0 {
+			retryAfter = 0
+		}
+		return false, 0, retryAfter
+	}
+
+	b.tokens--
+	return true, b.tokens, 0
+}
+
+// Snapshot is a read-only view of the limiter state for the given key. It is
+// primarily useful in tests and for introspection endpoints.
+type Snapshot struct {
+	Tokens     int
+	Capacity   int
+	LastRefill time.Time
+}
+
+// SnapshotKey returns the current state of a key without consuming a token.
+func (l *Limiter) SnapshotKey(key string) (Snapshot, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b, ok := l.buckets[key]
+	if !ok {
+		return Snapshot{}, false
+	}
+	return Snapshot{Tokens: b.tokens, Capacity: l.limit.Capacity, LastRefill: b.lastRefill}, true
+}
+
+// Middleware returns a Gin middleware that enforces the limiter against keys
+// produced by keyFn. Requests for which keyFn returns an empty string are
+// passed through unchecked. The middleware sets standard X-RateLimit-* headers
+// on every response.
+func (l *Limiter) Middleware(keyFn KeyFunc) gin.HandlerFunc {
+	if keyFn == nil {
+		keyFn = defaultKeyFn
+	}
+	return func(c *gin.Context) {
+		key := keyFn(c)
+		if key == "" {
+			c.Next()
+			return
+		}
+		allowed, remaining, retry := l.take(key, time.Now())
+		c.Header("X-RateLimit-Limit", strconv.Itoa(l.limit.Capacity))
+		c.Header("X-RateLimit-Remaining", strconv.Itoa(remaining))
+		if !allowed {
+			seconds := int(retry.Seconds())
+			if seconds < 1 {
+				seconds = 1
+			}
+			c.Header("Retry-After", strconv.Itoa(seconds))
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error":       "rate limit exceeded",
+				"retry_after": seconds,
+			})
+			return
+		}
+		c.Next()
+	}
+}
+
+// defaultKeyFn falls back to the client's IP address. It honours
+// X-Forwarded-For when present so deployments behind a trusted proxy work
+// out of the box.
+func defaultKeyFn(c *gin.Context) string {
+	if ip := c.GetHeader("X-Forwarded-For"); ip != "" {
+		return ip
+	}
+	return c.ClientIP()
+}
+
+// UserOrIPKey returns a KeyFunc that prefers the authenticated user ID and
+// falls back to client IP. Useful for endpoints that allow both authenticated
+// and anonymous traffic.
+func UserOrIPKey(c *gin.Context) string {
+	if v, ok := c.Get("user_id"); ok {
+		switch id := v.(type) {
+		case int64:
+			if id > 0 {
+				return "u:" + strconv.FormatInt(id, 10)
+			}
+		case int:
+			if id > 0 {
+				return "u:" + strconv.Itoa(id)
+			}
+		}
+	}
+	return "ip:" + defaultKeyFn(c)
+}

--- a/backend/internal/models/achievements.go
+++ b/backend/internal/models/achievements.go
@@ -1,0 +1,271 @@
+// Package models - achievements.go defines a small achievements system.
+//
+// The catalogue is hard-coded at compile time (the set of recognised
+// achievements is finite and changes only with releases). Unlocks are stored
+// in the user_achievements table; the evaluator inspects scoreboard rows to
+// decide which achievements a user currently qualifies for, then upserts new
+// unlocks.
+package models
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// AchievementID is a stable string identifier for an achievement. Changing
+// these breaks already-unlocked rows, so prefer additive changes.
+type AchievementID string
+
+const (
+	AchFirstWin       AchievementID = "first_win"
+	AchTenWins        AchievementID = "ten_wins"
+	AchFiftyWins      AchievementID = "fifty_wins"
+	AchHundredWins    AchievementID = "hundred_wins"
+	AchTenPlayed      AchievementID = "ten_played"
+	AchHundredPlayed  AchievementID = "hundred_played"
+	AchWinRate60      AchievementID = "win_rate_60"
+	AchWinRate75      AchievementID = "win_rate_75"
+	AchNightOwl       AchievementID = "night_owl"
+	AchEarlyBird      AchievementID = "early_bird"
+)
+
+// Achievement is the public-facing definition of an achievement.
+type Achievement struct {
+	ID          AchievementID `json:"id"`
+	Title       string        `json:"title"`
+	Description string        `json:"description"`
+	Icon        string        `json:"icon"` // emoji or icon code
+	Tier        string        `json:"tier"` // bronze, silver, gold, platinum
+}
+
+// UnlockedAchievement adds unlock metadata to an Achievement.
+type UnlockedAchievement struct {
+	Achievement
+	UnlockedAt time.Time `json:"unlocked_at"`
+}
+
+// Catalogue is the canonical list of achievements served to clients.
+var Catalogue = []Achievement{
+	{ID: AchFirstWin, Title: "First Win", Description: "Win your very first game.", Icon: "🥇", Tier: "bronze"},
+	{ID: AchTenWins, Title: "Ten Wins", Description: "Win 10 games.", Icon: "🏅", Tier: "silver"},
+	{ID: AchFiftyWins, Title: "Half Century", Description: "Win 50 games.", Icon: "🏆", Tier: "gold"},
+	{ID: AchHundredWins, Title: "Centurion", Description: "Win 100 games.", Icon: "👑", Tier: "platinum"},
+	{ID: AchTenPlayed, Title: "Getting Started", Description: "Play 10 games.", Icon: "🎲", Tier: "bronze"},
+	{ID: AchHundredPlayed, Title: "Regular", Description: "Play 100 games.", Icon: "🎮", Tier: "gold"},
+	{ID: AchWinRate60, Title: "Skilled", Description: "Reach 60% win rate (min 20 games).", Icon: "🎯", Tier: "silver"},
+	{ID: AchWinRate75, Title: "Elite", Description: "Reach 75% win rate (min 20 games).", Icon: "🌟", Tier: "platinum"},
+	{ID: AchNightOwl, Title: "Night Owl", Description: "Finish a game between midnight and 4am UTC.", Icon: "🦉", Tier: "bronze"},
+	{ID: AchEarlyBird, Title: "Early Bird", Description: "Finish a game between 5am and 8am UTC.", Icon: "🌅", Tier: "bronze"},
+}
+
+var catalogueByID map[AchievementID]Achievement
+
+func init() {
+	catalogueByID = make(map[AchievementID]Achievement, len(Catalogue))
+	for _, a := range Catalogue {
+		catalogueByID[a.ID] = a
+	}
+}
+
+// LookupAchievement returns the catalogue entry for id, if any.
+func LookupAchievement(id AchievementID) (Achievement, bool) {
+	a, ok := catalogueByID[id]
+	return a, ok
+}
+
+// EnsureAchievementsSchema creates the user_achievements table if missing.
+func EnsureAchievementsSchema(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, `
+		CREATE TABLE IF NOT EXISTS user_achievements (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			user_id INTEGER NOT NULL,
+			achievement_id TEXT NOT NULL,
+			unlocked_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(user_id, achievement_id)
+		)
+	`)
+	if err != nil {
+		return fmt.Errorf("EnsureAchievementsSchema: %w", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_user_achievements_user ON user_achievements(user_id)`)
+	if err != nil {
+		return fmt.Errorf("EnsureAchievementsSchema: idx: %w", err)
+	}
+	return nil
+}
+
+// UnlockSnapshot captures what a user has unlocked and what is still locked.
+type UnlockSnapshot struct {
+	Unlocked []UnlockedAchievement `json:"unlocked"`
+	Locked   []Achievement         `json:"locked"`
+}
+
+// ListAchievementsForUser returns a snapshot of unlocked + locked
+// achievements. The unlocked list is sorted by unlock time descending; the
+// locked list follows the catalogue order.
+func ListAchievementsForUser(ctx context.Context, db *sql.DB, userID int64) (*UnlockSnapshot, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT achievement_id, unlocked_at FROM user_achievements WHERE user_id = ?
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("ListAchievementsForUser: %w", err)
+	}
+	defer rows.Close()
+
+	unlockedTimes := make(map[AchievementID]time.Time, len(Catalogue))
+	for rows.Next() {
+		var id AchievementID
+		var ts time.Time
+		if err := rows.Scan(&id, &ts); err != nil {
+			return nil, fmt.Errorf("ListAchievementsForUser: scan: %w", err)
+		}
+		unlockedTimes[id] = ts
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("ListAchievementsForUser: iter: %w", err)
+	}
+
+	out := &UnlockSnapshot{
+		Unlocked: make([]UnlockedAchievement, 0, len(unlockedTimes)),
+		Locked:   make([]Achievement, 0, len(Catalogue)),
+	}
+	for _, a := range Catalogue {
+		if ts, ok := unlockedTimes[a.ID]; ok {
+			out.Unlocked = append(out.Unlocked, UnlockedAchievement{Achievement: a, UnlockedAt: ts})
+		} else {
+			out.Locked = append(out.Locked, a)
+		}
+	}
+	sort.Slice(out.Unlocked, func(i, j int) bool {
+		return out.Unlocked[i].UnlockedAt.After(out.Unlocked[j].UnlockedAt)
+	})
+	return out, nil
+}
+
+// PlayerStatsSnapshot is the subset of stats the evaluator consumes. Keeping
+// it as a plain struct makes it cheap to construct from any data source
+// (queries, fixtures, tests).
+type PlayerStatsSnapshot struct {
+	GamesPlayed int64
+	GamesWon    int64
+	// HourUTC is the hour of the most recently finished game in UTC.
+	// Negative values indicate "no recent game".
+	HourUTC int
+}
+
+// EvaluateForStats returns the set of achievement IDs that the given stats
+// satisfy. It does not touch the database; pair with PersistUnlocks to write
+// any newly-unlocked rows.
+func EvaluateForStats(s PlayerStatsSnapshot) []AchievementID {
+	out := make([]AchievementID, 0, 4)
+	if s.GamesWon >= 1 {
+		out = append(out, AchFirstWin)
+	}
+	if s.GamesWon >= 10 {
+		out = append(out, AchTenWins)
+	}
+	if s.GamesWon >= 50 {
+		out = append(out, AchFiftyWins)
+	}
+	if s.GamesWon >= 100 {
+		out = append(out, AchHundredWins)
+	}
+	if s.GamesPlayed >= 10 {
+		out = append(out, AchTenPlayed)
+	}
+	if s.GamesPlayed >= 100 {
+		out = append(out, AchHundredPlayed)
+	}
+	if s.GamesPlayed >= 20 {
+		rate := float64(s.GamesWon) / float64(s.GamesPlayed)
+		if rate >= 0.60 {
+			out = append(out, AchWinRate60)
+		}
+		if rate >= 0.75 {
+			out = append(out, AchWinRate75)
+		}
+	}
+	if s.HourUTC >= 0 && s.HourUTC < 4 {
+		out = append(out, AchNightOwl)
+	}
+	if s.HourUTC >= 5 && s.HourUTC < 8 {
+		out = append(out, AchEarlyBird)
+	}
+	return out
+}
+
+// PersistUnlocks inserts new (user, achievement) rows for ids that the user
+// has not yet unlocked. Returns the IDs that were newly inserted.
+func PersistUnlocks(ctx context.Context, db *sql.DB, userID int64, ids []AchievementID) ([]AchievementID, error) {
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("PersistUnlocks: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	stmt, err := tx.PrepareContext(ctx, `
+		INSERT INTO user_achievements (user_id, achievement_id)
+		VALUES (?, ?)
+		ON CONFLICT(user_id, achievement_id) DO NOTHING
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("PersistUnlocks: prepare: %w", err)
+	}
+	defer stmt.Close()
+
+	newlyUnlocked := make([]AchievementID, 0, len(ids))
+	for _, id := range ids {
+		if _, ok := catalogueByID[id]; !ok {
+			continue
+		}
+		res, err := stmt.ExecContext(ctx, userID, id)
+		if err != nil {
+			return nil, fmt.Errorf("PersistUnlocks: exec %s: %w", id, err)
+		}
+		if n, _ := res.RowsAffected(); n > 0 {
+			newlyUnlocked = append(newlyUnlocked, id)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("PersistUnlocks: commit: %w", err)
+	}
+	return newlyUnlocked, nil
+}
+
+// EvaluateAndPersistForUser pulls fresh stats from the scoreboard table for
+// userID, evaluates achievements, and persists any new unlocks. Returns the
+// IDs newly granted in this call so callers can broadcast a notification.
+func EvaluateAndPersistForUser(ctx context.Context, db *sql.DB, userID int64) ([]AchievementID, error) {
+	var snap PlayerStatsSnapshot
+	err := db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*) AS games_played,
+			SUM(CASE WHEN position = 1 THEN 1 ELSE 0 END) AS games_won
+		FROM scoreboard WHERE user_id = ?
+	`, userID).Scan(&snap.GamesPlayed, &snap.GamesWon)
+	if err != nil {
+		return nil, fmt.Errorf("EvaluateAndPersistForUser: stats: %w", err)
+	}
+
+	// Hour of last finished game (UTC). Optional; -1 if none.
+	snap.HourUTC = -1
+	var lastTs sql.NullTime
+	err = db.QueryRowContext(ctx, `
+		SELECT MAX(created_at) FROM scoreboard WHERE user_id = ?
+	`, userID).Scan(&lastTs)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("EvaluateAndPersistForUser: last_ts: %w", err)
+	}
+	if lastTs.Valid {
+		snap.HourUTC = lastTs.Time.UTC().Hour()
+	}
+
+	candidates := EvaluateForStats(snap)
+	return PersistUnlocks(ctx, db, userID, candidates)
+}

--- a/backend/internal/models/friends.go
+++ b/backend/internal/models/friends.go
@@ -1,0 +1,424 @@
+// Package models defines the persistence layer for application entities.
+// This file implements a lightweight friends/blocked-users feature:
+//
+//   - send a friend request from user A to user B
+//   - accept or decline an incoming request
+//   - list incoming, outgoing, and accepted relationships
+//   - remove an accepted friendship
+//   - block / unblock a user (one-directional)
+//
+// Relationships are stored in two tables: friendships (one row per pair,
+// canonicalised so user_a < user_b) and user_blocks (asymmetric, one row per
+// block direction). Callers are expected to initialise the schema once at
+// startup via EnsureFriendsSchema.
+package models
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// FriendshipStatus enumerates the lifecycle states of a friendship row.
+type FriendshipStatus string
+
+const (
+	FriendshipPending  FriendshipStatus = "pending"
+	FriendshipAccepted FriendshipStatus = "accepted"
+	FriendshipDeclined FriendshipStatus = "declined"
+)
+
+// Friendship is the canonical representation of a friendship row. The
+// "Requester" is the user who initiated the request; "Other" is the
+// counterparty. For accepted friendships either user may be the requester.
+type Friendship struct {
+	ID          int64            `json:"id"`
+	RequesterID int64            `json:"requester_id"`
+	OtherID     int64            `json:"other_id"`
+	Status      FriendshipStatus `json:"status"`
+	CreatedAt   time.Time        `json:"created_at"`
+	UpdatedAt   time.Time        `json:"updated_at"`
+}
+
+// FriendSummary is a lightweight view used by list endpoints.
+type FriendSummary struct {
+	UserID    int64     `json:"user_id"`
+	Username  string    `json:"username"`
+	AvatarURL *string   `json:"avatar_url,omitempty"`
+	Since     time.Time `json:"since"`
+}
+
+// FriendRequestView represents a pending request from the recipient's PoV.
+type FriendRequestView struct {
+	ID          int64     `json:"id"`
+	FromUserID  int64     `json:"from_user_id"`
+	FromUsername string   `json:"from_username"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+// Errors returned by the friends API.
+var (
+	ErrSelfFriendship       = errors.New("friends: cannot befriend yourself")
+	ErrAlreadyFriends       = errors.New("friends: already friends")
+	ErrRequestExists        = errors.New("friends: pending request already exists")
+	ErrBlocked              = errors.New("friends: relationship is blocked")
+	ErrRequestNotFound      = errors.New("friends: request not found")
+	ErrNotAuthorized        = errors.New("friends: not authorized")
+)
+
+// EnsureFriendsSchema creates the tables this module depends on if they do
+// not already exist. Safe to call repeatedly.
+func EnsureFriendsSchema(ctx context.Context, db *sql.DB) error {
+	stmts := []string{
+		`CREATE TABLE IF NOT EXISTS friendships (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			requester_id INTEGER NOT NULL,
+			other_id INTEGER NOT NULL,
+			status TEXT NOT NULL CHECK(status IN ('pending','accepted','declined')),
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			-- Enforce canonical ordering so a pair appears at most once.
+			CHECK(requester_id <> other_id),
+			UNIQUE(requester_id, other_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_friendships_other ON friendships(other_id, status)`,
+		`CREATE INDEX IF NOT EXISTS idx_friendships_requester ON friendships(requester_id, status)`,
+		`CREATE TABLE IF NOT EXISTS user_blocks (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			blocker_id INTEGER NOT NULL,
+			blocked_id INTEGER NOT NULL,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			UNIQUE(blocker_id, blocked_id),
+			CHECK(blocker_id <> blocked_id)
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_user_blocks_blocked ON user_blocks(blocked_id)`,
+	}
+	for _, s := range stmts {
+		if _, err := db.ExecContext(ctx, s); err != nil {
+			return fmt.Errorf("EnsureFriendsSchema: %w", err)
+		}
+	}
+	return nil
+}
+
+// SendFriendRequest creates a pending row from requester to other. Returns
+// ErrAlreadyFriends if the pair are already accepted friends, ErrRequestExists
+// if there is already a pending row in either direction, or ErrBlocked if
+// either party has blocked the other.
+func SendFriendRequest(ctx context.Context, db *sql.DB, requesterID, otherID int64) (*Friendship, error) {
+	if requesterID == otherID {
+		return nil, ErrSelfFriendship
+	}
+
+	if blocked, err := isEitherBlocked(ctx, db, requesterID, otherID); err != nil {
+		return nil, err
+	} else if blocked {
+		return nil, ErrBlocked
+	}
+
+	// Existing relationship check, in either direction.
+	existing, err := findFriendshipEitherDirection(ctx, db, requesterID, otherID)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return nil, err
+	}
+	if existing != nil {
+		switch existing.Status {
+		case FriendshipAccepted:
+			return nil, ErrAlreadyFriends
+		case FriendshipPending:
+			return nil, ErrRequestExists
+		case FriendshipDeclined:
+			// Allow re-requesting after a decline: bump status and timestamps.
+			_, err := db.ExecContext(ctx, `
+				UPDATE friendships
+				SET requester_id = ?, other_id = ?, status = 'pending', updated_at = CURRENT_TIMESTAMP
+				WHERE id = ?
+			`, requesterID, otherID, existing.ID)
+			if err != nil {
+				return nil, fmt.Errorf("SendFriendRequest: re-request: %w", err)
+			}
+			return loadFriendshipByID(ctx, db, existing.ID)
+		}
+	}
+
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO friendships (requester_id, other_id, status)
+		VALUES (?, ?, 'pending')
+	`, requesterID, otherID)
+	if err != nil {
+		return nil, fmt.Errorf("SendFriendRequest: insert: %w", err)
+	}
+	id, _ := res.LastInsertId()
+	return loadFriendshipByID(ctx, db, id)
+}
+
+// AcceptFriendRequest transitions a pending request to accepted. The actor
+// must be the recipient (i.e. the "other_id" on the row).
+func AcceptFriendRequest(ctx context.Context, db *sql.DB, requestID, actorID int64) (*Friendship, error) {
+	f, err := loadFriendshipByID(ctx, db, requestID)
+	if err != nil {
+		return nil, err
+	}
+	if f.Status != FriendshipPending {
+		return nil, ErrRequestNotFound
+	}
+	if f.OtherID != actorID {
+		return nil, ErrNotAuthorized
+	}
+	_, err = db.ExecContext(ctx, `
+		UPDATE friendships SET status = 'accepted', updated_at = CURRENT_TIMESTAMP WHERE id = ?
+	`, requestID)
+	if err != nil {
+		return nil, fmt.Errorf("AcceptFriendRequest: %w", err)
+	}
+	return loadFriendshipByID(ctx, db, requestID)
+}
+
+// DeclineFriendRequest transitions a pending request to declined. The actor
+// must be the recipient.
+func DeclineFriendRequest(ctx context.Context, db *sql.DB, requestID, actorID int64) error {
+	f, err := loadFriendshipByID(ctx, db, requestID)
+	if err != nil {
+		return err
+	}
+	if f.Status != FriendshipPending {
+		return ErrRequestNotFound
+	}
+	if f.OtherID != actorID {
+		return ErrNotAuthorized
+	}
+	_, err = db.ExecContext(ctx, `
+		UPDATE friendships SET status = 'declined', updated_at = CURRENT_TIMESTAMP WHERE id = ?
+	`, requestID)
+	if err != nil {
+		return fmt.Errorf("DeclineFriendRequest: %w", err)
+	}
+	return nil
+}
+
+// RemoveFriend deletes the accepted friendship between two users. It is a
+// no-op if no accepted friendship exists.
+func RemoveFriend(ctx context.Context, db *sql.DB, actorID, otherID int64) error {
+	_, err := db.ExecContext(ctx, `
+		DELETE FROM friendships
+		WHERE status = 'accepted'
+		  AND ((requester_id = ? AND other_id = ?) OR (requester_id = ? AND other_id = ?))
+	`, actorID, otherID, otherID, actorID)
+	if err != nil {
+		return fmt.Errorf("RemoveFriend: %w", err)
+	}
+	return nil
+}
+
+// ListFriends returns all accepted friendships for userID.
+func ListFriends(ctx context.Context, db *sql.DB, userID int64) ([]FriendSummary, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT u.id, u.username, u.avatar_url, f.updated_at
+		FROM friendships f
+		JOIN users u ON u.id = CASE WHEN f.requester_id = ? THEN f.other_id ELSE f.requester_id END
+		WHERE f.status = 'accepted' AND (f.requester_id = ? OR f.other_id = ?)
+		ORDER BY u.username COLLATE NOCASE ASC
+	`, userID, userID, userID)
+	if err != nil {
+		return nil, fmt.Errorf("ListFriends: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]FriendSummary, 0, 16)
+	for rows.Next() {
+		var s FriendSummary
+		var avatar sql.NullString
+		if err := rows.Scan(&s.UserID, &s.Username, &avatar, &s.Since); err != nil {
+			return nil, fmt.Errorf("ListFriends: scan: %w", err)
+		}
+		if avatar.Valid {
+			s.AvatarURL = &avatar.String
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// ListIncomingRequests returns pending requests addressed to userID.
+func ListIncomingRequests(ctx context.Context, db *sql.DB, userID int64) ([]FriendRequestView, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT f.id, f.requester_id, u.username, f.created_at
+		FROM friendships f
+		JOIN users u ON u.id = f.requester_id
+		WHERE f.status = 'pending' AND f.other_id = ?
+		ORDER BY f.created_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("ListIncomingRequests: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]FriendRequestView, 0, 8)
+	for rows.Next() {
+		var r FriendRequestView
+		if err := rows.Scan(&r.ID, &r.FromUserID, &r.FromUsername, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("ListIncomingRequests: scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// ListOutgoingRequests returns pending requests initiated by userID.
+func ListOutgoingRequests(ctx context.Context, db *sql.DB, userID int64) ([]FriendRequestView, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT f.id, f.other_id, u.username, f.created_at
+		FROM friendships f
+		JOIN users u ON u.id = f.other_id
+		WHERE f.status = 'pending' AND f.requester_id = ?
+		ORDER BY f.created_at DESC
+	`, userID)
+	if err != nil {
+		return nil, fmt.Errorf("ListOutgoingRequests: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]FriendRequestView, 0, 8)
+	for rows.Next() {
+		var r FriendRequestView
+		if err := rows.Scan(&r.ID, &r.FromUserID, &r.FromUsername, &r.CreatedAt); err != nil {
+			return nil, fmt.Errorf("ListOutgoingRequests: scan: %w", err)
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// BlockUser establishes a one-directional block from blocker to blocked, and
+// removes any pending or accepted friendship between them.
+func BlockUser(ctx context.Context, db *sql.DB, blockerID, blockedID int64) error {
+	if blockerID == blockedID {
+		return ErrSelfFriendship
+	}
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("BlockUser: begin: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	_, err = tx.ExecContext(ctx, `
+		INSERT INTO user_blocks (blocker_id, blocked_id)
+		VALUES (?, ?)
+		ON CONFLICT(blocker_id, blocked_id) DO NOTHING
+	`, blockerID, blockedID)
+	if err != nil {
+		return fmt.Errorf("BlockUser: insert: %w", err)
+	}
+
+	_, err = tx.ExecContext(ctx, `
+		DELETE FROM friendships
+		WHERE (requester_id = ? AND other_id = ?) OR (requester_id = ? AND other_id = ?)
+	`, blockerID, blockedID, blockedID, blockerID)
+	if err != nil {
+		return fmt.Errorf("BlockUser: clean friendships: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("BlockUser: commit: %w", err)
+	}
+	return nil
+}
+
+// UnblockUser removes a block, if one exists.
+func UnblockUser(ctx context.Context, db *sql.DB, blockerID, blockedID int64) error {
+	_, err := db.ExecContext(ctx, `
+		DELETE FROM user_blocks WHERE blocker_id = ? AND blocked_id = ?
+	`, blockerID, blockedID)
+	if err != nil {
+		return fmt.Errorf("UnblockUser: %w", err)
+	}
+	return nil
+}
+
+// ListBlocked returns all users blocked by blockerID.
+func ListBlocked(ctx context.Context, db *sql.DB, blockerID int64) ([]FriendSummary, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT u.id, u.username, u.avatar_url, b.created_at
+		FROM user_blocks b
+		JOIN users u ON u.id = b.blocked_id
+		WHERE b.blocker_id = ?
+		ORDER BY u.username COLLATE NOCASE ASC
+	`, blockerID)
+	if err != nil {
+		return nil, fmt.Errorf("ListBlocked: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]FriendSummary, 0, 8)
+	for rows.Next() {
+		var s FriendSummary
+		var avatar sql.NullString
+		if err := rows.Scan(&s.UserID, &s.Username, &avatar, &s.Since); err != nil {
+			return nil, fmt.Errorf("ListBlocked: scan: %w", err)
+		}
+		if avatar.Valid {
+			s.AvatarURL = &avatar.String
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// AreFriends reports whether a and b have an accepted friendship.
+func AreFriends(ctx context.Context, db *sql.DB, a, b int64) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM friendships
+		WHERE status = 'accepted'
+		  AND ((requester_id = ? AND other_id = ?) OR (requester_id = ? AND other_id = ?))
+	`, a, b, b, a).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("AreFriends: %w", err)
+	}
+	return n > 0, nil
+}
+
+// internal helpers --------------------------------------------------------
+
+func loadFriendshipByID(ctx context.Context, db *sql.DB, id int64) (*Friendship, error) {
+	var f Friendship
+	err := db.QueryRowContext(ctx, `
+		SELECT id, requester_id, other_id, status, created_at, updated_at
+		FROM friendships WHERE id = ?
+	`, id).Scan(&f.ID, &f.RequesterID, &f.OtherID, &f.Status, &f.CreatedAt, &f.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrRequestNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loadFriendshipByID: %w", err)
+	}
+	return &f, nil
+}
+
+func findFriendshipEitherDirection(ctx context.Context, db *sql.DB, a, b int64) (*Friendship, error) {
+	var f Friendship
+	err := db.QueryRowContext(ctx, `
+		SELECT id, requester_id, other_id, status, created_at, updated_at
+		FROM friendships
+		WHERE (requester_id = ? AND other_id = ?) OR (requester_id = ? AND other_id = ?)
+		LIMIT 1
+	`, a, b, b, a).Scan(&f.ID, &f.RequesterID, &f.OtherID, &f.Status, &f.CreatedAt, &f.UpdatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return &f, nil
+}
+
+func isEitherBlocked(ctx context.Context, db *sql.DB, a, b int64) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `
+		SELECT COUNT(*) FROM user_blocks
+		WHERE (blocker_id = ? AND blocked_id = ?) OR (blocker_id = ? AND blocked_id = ?)
+	`, a, b, b, a).Scan(&n)
+	if err != nil {
+		return false, fmt.Errorf("isEitherBlocked: %w", err)
+	}
+	return n > 0, nil
+}

--- a/backend/internal/models/leaderboard.go
+++ b/backend/internal/models/leaderboard.go
@@ -48,7 +48,8 @@ func BuildLeaderboard(ctx context.Context, db *sql.DB, days int64) (*Leaderboard
 		id       int64
 		username string
 	}
-	users := make([]u, 0)
+	// Capacity is unknown; start small to avoid early reallocations on typical user counts.
+	users := make([]u, 0, 64)
 	{
 		rows, err := db.QueryContext(ctx, `SELECT id, username FROM users ORDER BY username COLLATE NOCASE ASC`)
 		if err != nil {
@@ -146,14 +147,15 @@ func BuildLeaderboard(ctx context.Context, db *sql.DB, days int64) (*Leaderboard
 
 	// Build the date list (oldest -> newest) as YYYY-MM-DD in UTC to match SQLite DATE('now', ...).
 	start := time.Now().UTC().AddDate(0, 0, -int(days)+1)
-	dates := make([]string, 0, days)
+	dates := make([]string, days)
 	for i := int64(0); i < days; i++ {
-		d := start.AddDate(0, 0, int(i))
-		dates = append(dates, d.Format("2006-01-02"))
+		dates[i] = start.AddDate(0, 0, int(i)).Format("2006-01-02")
 	}
 
 	out := make([]LeaderboardPlayer, 0, len(users))
 	for _, usr := range users {
+		// Context cancellation is checked once per user, not per day.
+		// Per-day checks burn CPU on a syscall-free fast path; per-user is responsive enough.
 		if err := ctx.Err(); err != nil {
 			return nil, fmt.Errorf("BuildLeaderboard: context cancelled: %w", err)
 		}
@@ -163,14 +165,11 @@ func BuildLeaderboard(ctx context.Context, db *sql.DB, days int64) (*Leaderboard
 			allTimeRate = float64(t.won) / float64(t.played)
 		}
 
-		series := make([]LeaderboardDayPoint, 0, len(dates))
+		series := make([]LeaderboardDayPoint, len(dates))
 		cumPlayed := int64(0)
 		cumWon := int64(0)
 		dayMap := byUserDay[usr.id]
-		for _, day := range dates {
-			if err := ctx.Err(); err != nil {
-				return nil, fmt.Errorf("BuildLeaderboard: context cancelled: %w", err)
-			}
+		for i, day := range dates {
 			da := dayAgg{}
 			if dayMap != nil {
 				da = dayMap[day]
@@ -181,12 +180,12 @@ func BuildLeaderboard(ctx context.Context, db *sql.DB, days int64) (*Leaderboard
 			if cumPlayed > 0 {
 				wr = float64(cumWon) / float64(cumPlayed)
 			}
-			series = append(series, LeaderboardDayPoint{
+			series[i] = LeaderboardDayPoint{
 				Date:        day,
 				GamesPlayed: da.played,
 				GamesWon:    da.won,
 				WinRate:     wr,
-			})
+			}
 		}
 
 		out = append(out, LeaderboardPlayer{

--- a/backend/internal/models/lobby.go
+++ b/backend/internal/models/lobby.go
@@ -72,7 +72,7 @@ func ListLobbies(db *sql.DB, limit, offset int64) ([]Lobby, error) {
 	}
 	defer rows.Close()
 
-	out := make([]Lobby, 0)
+	out := make([]Lobby, 0, limit)
 	for rows.Next() {
 		var l Lobby
 		if err := rows.Scan(&l.ID, &l.Name, &l.HostID, &l.MaxPlayers, &l.CurrentPlayers, &l.Status, &l.CreatedAt); err != nil {

--- a/backend/pkg/websocket/hub.go
+++ b/backend/pkg/websocket/hub.go
@@ -4,8 +4,11 @@ import (
 	"encoding/json"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 )
+
+const broadcastQueueSize = 1024
 
 // Hub manages websocket clients and room-based broadcasts.
 type Hub struct {
@@ -18,6 +21,8 @@ type Hub struct {
 
 	stopOnce sync.Once
 	stop     chan struct{}
+
+	droppedBroadcasts atomic.Uint64
 }
 
 type joinReq struct {
@@ -36,7 +41,7 @@ func NewHub() *Hub {
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
 		join:       make(chan joinReq),
-		broadcast:  make(chan Broadcast, 256),
+		broadcast:  make(chan Broadcast, broadcastQueueSize),
 		rooms:      map[string]map[*Client]bool{},
 		stop:       make(chan struct{}),
 	}
@@ -107,17 +112,32 @@ func (h *Hub) Join(c *Client, room string) {
 }
 
 func (h *Hub) Broadcast(room, typ string, payload any) {
+	msg := Broadcast{Room: room, Type: typ, Payload: payload}
 	select {
 	case <-h.stop:
 		return
-	case h.broadcast <- Broadcast{Room: room, Type: typ, Payload: payload}:
+	case h.broadcast <- msg:
 		return
 	default:
-		// Drop rather than block forever (e.g., if Run() has exited and the
-		// channel buffer fills).
+	}
+	// Buffer full. Block briefly so we don't silently drop under load, but
+	// stay responsive to Stop() and bail if the queue is genuinely saturated.
+	select {
+	case <-h.stop:
 		return
+	case h.broadcast <- msg:
+	case <-time.After(50 * time.Millisecond):
+		n := h.droppedBroadcasts.Add(1)
+		// Log only occasionally to avoid flooding.
+		if n == 1 || n%100 == 0 {
+			log.Printf("ws broadcast dropped: room=%s type=%s total_dropped=%d", room, typ, n)
+		}
 	}
 }
+
+// DroppedBroadcasts returns the cumulative count of broadcasts dropped due to
+// a saturated queue. Useful for metrics and tests.
+func (h *Hub) DroppedBroadcasts() uint64 { return h.droppedBroadcasts.Load() }
 
 func (h *Hub) removeClient(c *Client) {
 	if c == nil {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,8 @@ import { CreateLobbyPage } from './pages/CreateLobbyPage'
 import { LobbyDetailPage } from './pages/LobbyDetailPage'
 import { GamePage } from './pages/GamePage'
 import { LeaderboardPage } from './pages/LeaderboardPage'
+import { FriendsPage } from './pages/FriendsPage'
+import { AchievementsPage } from './pages/AchievementsPage'
 
 function App() {
   return (
@@ -20,6 +22,8 @@ function App() {
         <Route path="/lobbies" element={<LobbiesPage />} />
         <Route path="/lobbies/new" element={<CreateLobbyPage />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
+        <Route path="/friends" element={<FriendsPage />} />
+        <Route path="/achievements" element={<AchievementsPage />} />
         <Route path="/lobbies/:id" element={<LobbyDetailPage />} />
         <Route path="/games/:id" element={<GamePage />} />
       </Route>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,7 +1,12 @@
 import { apiBaseUrl } from '../lib/env'
 import { ApiError, apiFetch } from '../lib/http'
 import type {
+  Achievement,
+  AchievementsSnapshot,
   AuthResponse,
+  FriendSummary,
+  FriendsListResponse,
+  Friendship,
   Game,
   GameMove,
   GameSnapshot,
@@ -10,6 +15,7 @@ import type {
   LobbyChatMessage,
   PresenceStatus,
   SpectatorInfo,
+  ToggleReactionResponse,
   User,
   UserStats,
 } from './types'
@@ -28,162 +34,216 @@ export type UpdatePresenceRequest = { status: 'online' | 'away' | 'in_game' | 'o
 
 const UNEXPECTED_EMPTY_RESPONSE_STATUS = 599
 
+// Most endpoints must return a non-empty body. apiFetch returns undefined for
+// 204/empty responses, so this asserts presence and narrows the type.
+function required<T>(res: T | undefined): T {
+  if (res === undefined || res === null) {
+    throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
+  }
+  return res
+}
+
+const url = (path: string) => `${apiBaseUrl()}${path}`
+
 export const api = {
   async register(req: RegisterRequest) {
-    const res = await apiFetch<AuthResponse>(`${apiBaseUrl()}/api/auth/register`, {
-      method: 'POST',
-      body: req,
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<AuthResponse>(url('/api/auth/register'), { method: 'POST', body: req }))
   },
   async login(req: LoginRequest) {
-    const res = await apiFetch<AuthResponse>(`${apiBaseUrl()}/api/auth/login`, {
-      method: 'POST',
-      body: req,
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<AuthResponse>(url('/api/auth/login'), { method: 'POST', body: req }))
   },
   async me() {
-    const res = await apiFetch<{ user: User }>(`${apiBaseUrl()}/api/auth/me`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<{ user: User }>(url('/api/auth/me')))
   },
   async logout() {
     // Logout is best-effort; empty 204/empty-body is OK.
-    await apiFetch<void>(`${apiBaseUrl()}/api/auth/logout`, { method: 'POST' })
+    await apiFetch<void>(url('/api/auth/logout'), { method: 'POST' })
   },
   async listLobbies() {
-    const res = await apiFetch<{ lobbies: Lobby[] }>(`${apiBaseUrl()}/api/lobbies`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<{ lobbies: Lobby[] }>(url('/api/lobbies')))
   },
   async createLobby(req: CreateLobbyRequest) {
-    const res = await apiFetch<{ lobby: Lobby; game: Game }>(`${apiBaseUrl()}/api/lobbies`, {
-      method: 'POST',
-      body: req,
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{ lobby: Lobby; game: Game }>(url('/api/lobbies'), { method: 'POST', body: req }),
+    )
   },
   async joinLobby(lobbyId: number) {
-    const res = await apiFetch<{
-      lobby: Lobby
-      game_id: number
-      joined_persisted?: boolean
-      realtime_sync?: string
-    }>(`${apiBaseUrl()}/api/lobbies/${lobbyId}/join`, {
-      method: 'POST',
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{
+        lobby: Lobby
+        game_id: number
+        joined_persisted?: boolean
+        realtime_sync?: string
+      }>(url(`/api/lobbies/${lobbyId}/join`), { method: 'POST' }),
+    )
   },
   async addBotToLobby(lobbyId: number, req: AddBotRequest = {}) {
-    const res = await apiFetch<{ game_id: number; bot_user_id: number; bot_username: string }>(
-      `${apiBaseUrl()}/api/lobbies/${lobbyId}/add_bot`,
-      {
-        method: 'POST',
-        body: req,
-      },
+    return required(
+      await apiFetch<{ game_id: number; bot_user_id: number; bot_username: string }>(
+        url(`/api/lobbies/${lobbyId}/add_bot`),
+        { method: 'POST', body: req },
+      ),
     )
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
   },
   async getGame(gameId: number) {
-    const res = await apiFetch<GameSnapshot>(`${apiBaseUrl()}/api/games/${gameId}`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<GameSnapshot>(url(`/api/games/${gameId}`)))
   },
   async getUserStats(userId: number) {
-    const res = await apiFetch<UserStats>(`${apiBaseUrl()}/api/scoreboard/${userId}`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<UserStats>(url(`/api/scoreboard/${userId}`)))
   },
   async getLeaderboard(days = 30) {
-    const qs = new URLSearchParams()
-    qs.set('days', String(days))
-    const res = await apiFetch<LeaderboardResponse>(`${apiBaseUrl()}/api/leaderboard?${qs.toString()}`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    const qs = new URLSearchParams({ days: String(days) })
+    return required(await apiFetch<LeaderboardResponse>(url(`/api/leaderboard?${qs.toString()}`)))
   },
   async listGameMoves(gameId: number) {
-    const res = await apiFetch<{ moves: GameMove[] }>(`${apiBaseUrl()}/api/games/${gameId}/moves`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<{ moves: GameMove[] }>(url(`/api/games/${gameId}/moves`)))
   },
   async quitGame(gameId: number) {
-    await apiFetch<void>(`${apiBaseUrl()}/api/games/${gameId}/quit`, { method: 'POST' })
+    await apiFetch<void>(url(`/api/games/${gameId}/quit`), { method: 'POST' })
   },
   async nextHand(gameId: number) {
-    await apiFetch<void>(`${apiBaseUrl()}/api/games/${gameId}/next_hand`, { method: 'POST' })
+    await apiFetch<void>(url(`/api/games/${gameId}/next_hand`), { method: 'POST' })
   },
 
   async moveGame(gameId: number, move: GameMoveRequest) {
-    const res = await apiFetch<unknown>(`${apiBaseUrl()}/api/games/${gameId}/move`, {
-      method: 'POST',
-      body: move,
-    })
-    if (res === undefined) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<unknown>(url(`/api/games/${gameId}/move`), { method: 'POST', body: move }),
+    )
   },
 
   // Lobby chat
   async getLobbyChatHistory(lobbyId: number, limit = 100) {
-    const res = await apiFetch<{ messages: LobbyChatMessage[] }>(`${apiBaseUrl()}/api/lobbies/${lobbyId}/chat?limit=${limit}`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{ messages: LobbyChatMessage[] }>(url(`/api/lobbies/${lobbyId}/chat?limit=${limit}`)),
+    )
   },
   async sendLobbyChatMessage(lobbyId: number, req: SendChatMessageRequest) {
-    const res = await apiFetch<LobbyChatMessage>(`${apiBaseUrl()}/api/lobbies/${lobbyId}/chat`, {
-      method: 'POST',
-      body: req,
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<LobbyChatMessage>(url(`/api/lobbies/${lobbyId}/chat`), { method: 'POST', body: req }),
+    )
   },
 
   // Spectators
   async joinAsSpectator(lobbyId: number) {
-    const res = await apiFetch<{ success: boolean; spectator: SpectatorInfo }>(`${apiBaseUrl()}/api/lobbies/${lobbyId}/spectate`, {
-      method: 'POST',
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{ success: boolean; spectator: SpectatorInfo }>(
+        url(`/api/lobbies/${lobbyId}/spectate`),
+        { method: 'POST' },
+      ),
+    )
   },
   async leaveAsSpectator(lobbyId: number) {
-    const res = await apiFetch<{ success: boolean }>(`${apiBaseUrl()}/api/lobbies/${lobbyId}/spectate`, {
-      method: 'DELETE',
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{ success: boolean }>(url(`/api/lobbies/${lobbyId}/spectate`), { method: 'DELETE' }),
+    )
   },
   async getSpectators(lobbyId: number) {
-    const res = await apiFetch<{ spectators: SpectatorInfo[] }>(`${apiBaseUrl()}/api/lobbies/${lobbyId}/spectators`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{ spectators: SpectatorInfo[] }>(url(`/api/lobbies/${lobbyId}/spectators`)),
+    )
   },
 
   // User presence
   async updatePresence(req: UpdatePresenceRequest) {
-    const res = await apiFetch<PresenceStatus>(`${apiBaseUrl()}/api/users/presence`, {
-      method: 'PUT',
-      body: req,
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<PresenceStatus>(url('/api/users/presence'), { method: 'PUT', body: req }),
+    )
   },
   async presenceHeartbeat() {
-    const res = await apiFetch<{ success: boolean }>(`${apiBaseUrl()}/api/users/presence/heartbeat`, {
-      method: 'POST',
-    })
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(
+      await apiFetch<{ success: boolean }>(url('/api/users/presence/heartbeat'), { method: 'POST' }),
+    )
   },
   async getUserPresence(userId: number) {
-    const res = await apiFetch<PresenceStatus>(`${apiBaseUrl()}/api/users/${userId}/presence`)
-    if (!res) throw new ApiError('Unexpected empty response', UNEXPECTED_EMPTY_RESPONSE_STATUS)
-    return res
+    return required(await apiFetch<PresenceStatus>(url(`/api/users/${userId}/presence`)))
+  },
+
+  // ---------------------------------------------------------------------------
+  // Friends
+  // ---------------------------------------------------------------------------
+  async listFriends() {
+    return required(await apiFetch<FriendsListResponse>(url('/api/friends')))
+  },
+  async sendFriendRequest(userId: number) {
+    return required(
+      await apiFetch<{ request: Friendship }>(url('/api/friends/requests'), {
+        method: 'POST',
+        body: { user_id: userId },
+      }),
+    )
+  },
+  async acceptFriendRequest(requestId: number) {
+    return required(
+      await apiFetch<{ friendship: Friendship }>(url(`/api/friends/requests/${requestId}/accept`), {
+        method: 'POST',
+      }),
+    )
+  },
+  async declineFriendRequest(requestId: number) {
+    return required(
+      await apiFetch<{ success: boolean }>(url(`/api/friends/requests/${requestId}/decline`), {
+        method: 'POST',
+      }),
+    )
+  },
+  async removeFriend(userId: number) {
+    return required(
+      await apiFetch<{ success: boolean }>(url(`/api/friends/${userId}`), { method: 'DELETE' }),
+    )
+  },
+  async blockUser(userId: number) {
+    return required(
+      await apiFetch<{ success: boolean }>(url('/api/friends/blocks'), {
+        method: 'POST',
+        body: { user_id: userId },
+      }),
+    )
+  },
+  async unblockUser(userId: number) {
+    return required(
+      await apiFetch<{ success: boolean }>(url(`/api/friends/blocks/${userId}`), { method: 'DELETE' }),
+    )
+  },
+  async listBlocked() {
+    return required(await apiFetch<{ blocked: FriendSummary[] }>(url('/api/friends/blocks')))
+  },
+
+  // ---------------------------------------------------------------------------
+  // Achievements
+  // ---------------------------------------------------------------------------
+  async getAchievementCatalogue() {
+    return required(await apiFetch<{ achievements: Achievement[] }>(url('/api/achievements/catalogue')))
+  },
+  async getMyAchievements() {
+    return required(await apiFetch<AchievementsSnapshot>(url('/api/achievements')))
+  },
+  async getUserAchievements(userId: number) {
+    return required(await apiFetch<AchievementsSnapshot>(url(`/api/users/${userId}/achievements`)))
+  },
+  async evaluateMyAchievements() {
+    return required(
+      await apiFetch<{ newly_unlocked: Achievement[] }>(url('/api/achievements/evaluate'), {
+        method: 'POST',
+      }),
+    )
+  },
+
+  // ---------------------------------------------------------------------------
+  // Chat reactions
+  // ---------------------------------------------------------------------------
+  async toggleReaction(lobbyId: number, msgId: number, emoji: string) {
+    return required(
+      await apiFetch<ToggleReactionResponse>(url(`/api/lobbies/${lobbyId}/chat/${msgId}/react`), {
+        method: 'POST',
+        body: { emoji },
+      }),
+    )
+  },
+  async getMessageReactions(lobbyId: number, msgId: number) {
+    return required(
+      await apiFetch<{ reactions: ToggleReactionResponse['reactions'] }>(
+        url(`/api/lobbies/${lobbyId}/chat/${msgId}/reactions`),
+      ),
+    )
   },
 }
-

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -162,3 +162,78 @@ export type GameMove = {
   created_at: string
 }
 
+// -----------------------------------------------------------------------------
+// Friends & blocks
+// -----------------------------------------------------------------------------
+
+export type FriendshipStatus = 'pending' | 'accepted' | 'declined'
+
+export type Friendship = {
+  id: number
+  requester_id: number
+  other_id: number
+  status: FriendshipStatus
+  created_at: string
+  updated_at: string
+}
+
+export type FriendSummary = {
+  user_id: number
+  username: string
+  avatar_url?: string | null
+  since: string
+}
+
+export type FriendRequestView = {
+  id: number
+  from_user_id: number
+  from_username: string
+  created_at: string
+}
+
+export type FriendsListResponse = {
+  friends: FriendSummary[]
+  incoming: FriendRequestView[]
+  outgoing: FriendRequestView[]
+}
+
+// -----------------------------------------------------------------------------
+// Achievements
+// -----------------------------------------------------------------------------
+
+export type AchievementTier = 'bronze' | 'silver' | 'gold' | 'platinum'
+
+export type Achievement = {
+  id: string
+  title: string
+  description: string
+  icon: string
+  tier: AchievementTier
+}
+
+export type UnlockedAchievement = Achievement & {
+  unlocked_at: string
+}
+
+export type AchievementsSnapshot = {
+  unlocked: UnlockedAchievement[]
+  locked: Achievement[]
+}
+
+// -----------------------------------------------------------------------------
+// Chat reactions
+// -----------------------------------------------------------------------------
+
+export type ReactionView = {
+  emoji: string
+  count: number
+  user_ids: number[]
+  reacted: boolean
+}
+
+export type ToggleReactionResponse = {
+  message_id: number
+  reactions: ReactionView[]
+  added: boolean
+}
+

--- a/frontend/src/components/LobbyChat.tsx
+++ b/frontend/src/components/LobbyChat.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react'
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react'
+import type { CSSProperties } from 'react'
 import { api } from '../api/client'
 import type { LobbyChatMessage } from '../api/types'
 
@@ -8,6 +9,71 @@ interface LobbyChatProps {
 
 export type LobbyChatHandle = {
   addMessage: (message: LobbyChatMessage) => void
+}
+
+// Static styles hoisted to module scope so referential identity is stable
+// across renders. Anything that depends on state stays in JSX.
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
+  border: '1px solid #ddd',
+  borderRadius: '8px',
+  backgroundColor: '#fff',
+}
+
+const headerStyle: CSSProperties = {
+  padding: '12px 16px',
+  borderBottom: '1px solid #ddd',
+  fontWeight: 'bold',
+  fontSize: '1.1em',
+}
+
+const messageListStyle: CSSProperties = {
+  flex: 1,
+  overflowY: 'auto',
+  padding: '16px',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '12px',
+}
+
+const emptyStateStyle: CSSProperties = { color: '#999', textAlign: 'center', marginTop: '20px' }
+const chatHeaderRowStyle: CSSProperties = { display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }
+const usernameStyle: CSSProperties = { color: '#333' }
+const timestampStyle: CSSProperties = { color: '#999', fontSize: '0.85em' }
+
+const inputRowContainerStyle: CSSProperties = { padding: '12px 16px', borderTop: '1px solid #ddd' }
+const errorStyle: CSSProperties = { color: 'crimson', marginBottom: '8px', fontSize: '0.9em' }
+const inputRowStyle: CSSProperties = { display: 'flex', gap: '8px' }
+const inputStyle: CSSProperties = {
+  flex: 1,
+  padding: '8px 12px',
+  border: '1px solid #ddd',
+  borderRadius: '4px',
+  fontSize: '1em',
+}
+
+const systemMsgStyle: CSSProperties = { fontStyle: 'italic', color: '#666', fontSize: '0.9em' }
+const joinMsgStyle: CSSProperties = { fontStyle: 'italic', color: '#4a9eff', fontSize: '0.9em' }
+const leaveMsgStyle: CSSProperties = { fontStyle: 'italic', color: '#999', fontSize: '0.9em' }
+const emptyTypeStyle: CSSProperties = {}
+
+function styleForMessageType(messageType: string): CSSProperties {
+  switch (messageType) {
+    case 'system':
+      return systemMsgStyle
+    case 'join':
+      return joinMsgStyle
+    case 'leave':
+      return leaveMsgStyle
+    default:
+      return emptyTypeStyle
+  }
+}
+
+function formatTime(timestamp: string): string {
+  return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 }
 
 export const LobbyChat = forwardRef<LobbyChatHandle, LobbyChatProps>(function LobbyChat({ lobbyId }: LobbyChatProps, ref) {
@@ -40,11 +106,13 @@ export const LobbyChat = forwardRef<LobbyChatHandle, LobbyChatProps>(function Lo
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [messages])
 
-  const addMessage = (message: LobbyChatMessage) => {
-    setMessages((prev) => [...prev, message])
-  }
-
-  useImperativeHandle(ref, () => ({ addMessage }), [])
+  useImperativeHandle(
+    ref,
+    () => ({
+      addMessage: (message: LobbyChatMessage) => setMessages((prev) => [...prev, message]),
+    }),
+    [],
+  )
 
   const handleSend = async () => {
     if (!inputMessage.trim() || isSending) return
@@ -54,7 +122,6 @@ export const LobbyChat = forwardRef<LobbyChatHandle, LobbyChatProps>(function Lo
     try {
       await api.sendLobbyChatMessage(lobbyId, { message: inputMessage.trim() })
       // Message will be broadcast via WebSocket and received by all clients
-      // We could optimistically add it here, but the broadcast will handle it
       setInputMessage('')
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to send message')
@@ -70,90 +137,52 @@ export const LobbyChat = forwardRef<LobbyChatHandle, LobbyChatProps>(function Lo
     }
   }
 
-  const formatTime = (timestamp: string) => {
-    const date = new Date(timestamp)
-    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-  }
-
-  const getMessageStyle = (messageType: string) => {
-    switch (messageType) {
-      case 'system':
-        return { fontStyle: 'italic', color: '#666', fontSize: '0.9em' }
-      case 'join':
-        return { fontStyle: 'italic', color: '#4a9eff', fontSize: '0.9em' }
-      case 'leave':
-        return { fontStyle: 'italic', color: '#999', fontSize: '0.9em' }
-      default:
-        return {}
-    }
-  }
+  const canSend = inputMessage.trim().length > 0 && !isSending
+  const sendButtonStyle = useMemo<CSSProperties>(
+    () => ({
+      padding: '8px 16px',
+      backgroundColor: canSend ? '#4a9eff' : '#ddd',
+      color: canSend ? '#fff' : '#999',
+      border: 'none',
+      borderRadius: '4px',
+      cursor: canSend ? 'pointer' : 'not-allowed',
+      fontWeight: 'bold',
+    }),
+    [canSend],
+  )
 
   return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      height: '100%',
-      border: '1px solid #ddd',
-      borderRadius: '8px',
-      backgroundColor: '#fff',
-    }}>
-      <div style={{
-        padding: '12px 16px',
-        borderBottom: '1px solid #ddd',
-        fontWeight: 'bold',
-        fontSize: '1.1em',
-      }}>
-        Lobby Chat
-      </div>
+    <div style={containerStyle}>
+      <div style={headerStyle}>Lobby Chat</div>
 
-      <div
-        ref={chatContainerRef}
-        style={{
-          flex: 1,
-          overflowY: 'auto',
-          padding: '16px',
-          display: 'flex',
-          flexDirection: 'column',
-          gap: '12px',
-        }}
-      >
-        {messages.length === 0 && (
-          <div style={{ color: '#999', textAlign: 'center', marginTop: '20px' }}>
-            No messages yet. Start the conversation!
-          </div>
-        )}
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            style={{
-              ...getMessageStyle(msg.message_type),
-              padding: msg.message_type === 'chat' ? '8px 12px' : '4px 8px',
-              backgroundColor: msg.message_type === 'chat' ? '#f5f5f5' : 'transparent',
-              borderRadius: '6px',
-            }}
-          >
-            {msg.message_type === 'chat' && (
-              <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px' }}>
-                <strong style={{ color: '#333' }}>{msg.username}</strong>
-                <span style={{ color: '#999', fontSize: '0.85em' }}>{formatTime(msg.created_at)}</span>
-              </div>
-            )}
-            <div>{msg.message}</div>
-          </div>
-        ))}
+      <div ref={chatContainerRef} style={messageListStyle}>
+        {messages.length === 0 && <div style={emptyStateStyle}>No messages yet. Start the conversation!</div>}
+        {messages.map((msg) => {
+          const isChat = msg.message_type === 'chat'
+          const rowStyle: CSSProperties = {
+            ...styleForMessageType(msg.message_type),
+            padding: isChat ? '8px 12px' : '4px 8px',
+            backgroundColor: isChat ? '#f5f5f5' : 'transparent',
+            borderRadius: '6px',
+          }
+          return (
+            <div key={msg.id} style={rowStyle}>
+              {isChat && (
+                <div style={chatHeaderRowStyle}>
+                  <strong style={usernameStyle}>{msg.username}</strong>
+                  <span style={timestampStyle}>{formatTime(msg.created_at)}</span>
+                </div>
+              )}
+              <div>{msg.message}</div>
+            </div>
+          )
+        })}
         <div ref={messagesEndRef} />
       </div>
 
-      <div style={{
-        padding: '12px 16px',
-        borderTop: '1px solid #ddd',
-      }}>
-        {error && (
-          <div style={{ color: 'crimson', marginBottom: '8px', fontSize: '0.9em' }}>
-            {error}
-          </div>
-        )}
-        <div style={{ display: 'flex', gap: '8px' }}>
+      <div style={inputRowContainerStyle}>
+        {error && <div style={errorStyle}>{error}</div>}
+        <div style={inputRowStyle}>
           <input
             type="text"
             value={inputMessage}
@@ -161,27 +190,9 @@ export const LobbyChat = forwardRef<LobbyChatHandle, LobbyChatProps>(function Lo
             onKeyDown={handleKeyDown}
             placeholder="Type a message..."
             disabled={isSending}
-            style={{
-              flex: 1,
-              padding: '8px 12px',
-              border: '1px solid #ddd',
-              borderRadius: '4px',
-              fontSize: '1em',
-            }}
+            style={inputStyle}
           />
-          <button
-            onClick={handleSend}
-            disabled={!inputMessage.trim() || isSending}
-            style={{
-              padding: '8px 16px',
-              backgroundColor: inputMessage.trim() && !isSending ? '#4a9eff' : '#ddd',
-              color: inputMessage.trim() && !isSending ? '#fff' : '#999',
-              border: 'none',
-              borderRadius: '4px',
-              cursor: inputMessage.trim() && !isSending ? 'pointer' : 'not-allowed',
-              fontWeight: 'bold',
-            }}
-          >
+          <button onClick={handleSend} disabled={!canSend} style={sendButtonStyle}>
             {isSending ? 'Sending...' : 'Send'}
           </button>
         </div>
@@ -192,4 +203,3 @@ export const LobbyChat = forwardRef<LobbyChatHandle, LobbyChatProps>(function Lo
 
 // Note: If you need websocket-driven lobby chat, prefer rendering <LobbyChat ref={...} />
 // and calling ref.current.addMessage(...) from the websocket handler.
-

--- a/frontend/src/pages/AchievementsPage.tsx
+++ b/frontend/src/pages/AchievementsPage.tsx
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { api } from '../api/client'
+import type { Achievement, AchievementsSnapshot, UnlockedAchievement } from '../api/types'
+import { useAuth } from '../auth/auth'
+
+// AchievementsPage renders unlocked and locked achievements for the current
+// user. Includes a "Re-evaluate" button that recomputes the achievement set
+// from current stats — useful right after a finished game.
+
+const pageStyle: CSSProperties = { padding: '24px', maxWidth: 980, margin: '0 auto' }
+const headerStyle: CSSProperties = { fontSize: 28, fontWeight: 800, margin: '0 0 8px 0' }
+const subtitleStyle: CSSProperties = { color: '#6b7280', marginBottom: 24 }
+
+const toolbarStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  marginBottom: 16,
+}
+const primaryButtonStyle: CSSProperties = {
+  padding: '8px 14px',
+  background: '#4a9eff',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontWeight: 600,
+}
+const sectionStyle: CSSProperties = {
+  background: '#fff',
+  border: '1px solid #e5e7eb',
+  borderRadius: 12,
+  padding: 20,
+  marginBottom: 20,
+  boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+}
+const sectionTitleStyle: CSSProperties = { fontSize: 18, fontWeight: 700, marginBottom: 12 }
+const subtleStyle: CSSProperties = { color: '#6b7280', fontSize: 13 }
+const gridStyle: CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+  gap: 12,
+}
+const tierBronze: CSSProperties = { background: 'linear-gradient(135deg,#fde68a,#fbbf24)', color: '#7c2d12' }
+const tierSilver: CSSProperties = { background: 'linear-gradient(135deg,#e5e7eb,#9ca3af)', color: '#1f2937' }
+const tierGold: CSSProperties = { background: 'linear-gradient(135deg,#fef08a,#eab308)', color: '#713f12' }
+const tierPlatinum: CSSProperties = { background: 'linear-gradient(135deg,#e0e7ff,#a5b4fc)', color: '#312e81' }
+
+function tierStyle(tier: string): CSSProperties {
+  switch (tier) {
+    case 'silver':
+      return tierSilver
+    case 'gold':
+      return tierGold
+    case 'platinum':
+      return tierPlatinum
+    case 'bronze':
+    default:
+      return tierBronze
+  }
+}
+
+function cardStyle(unlocked: boolean): CSSProperties {
+  return {
+    padding: 16,
+    borderRadius: 12,
+    border: '1px solid #e5e7eb',
+    background: unlocked ? '#ffffff' : '#f9fafb',
+    opacity: unlocked ? 1 : 0.7,
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    minHeight: 130,
+  }
+}
+
+const iconBadgeStyle: CSSProperties = {
+  width: 44,
+  height: 44,
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontSize: 24,
+  fontWeight: 800,
+}
+
+const titleStyle: CSSProperties = { fontSize: 16, fontWeight: 700 }
+const descStyle: CSSProperties = { color: '#374151', fontSize: 13 }
+const metaStyle: CSSProperties = { color: '#6b7280', fontSize: 12 }
+const tierChipStyle: CSSProperties = {
+  display: 'inline-block',
+  padding: '2px 8px',
+  borderRadius: 999,
+  fontSize: 11,
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: 0.4,
+}
+
+const errorStyle: CSSProperties = { color: '#b91c1c', marginBottom: 12 }
+const okStyle: CSSProperties = { color: '#047857', marginBottom: 12 }
+
+function formatDate(ts: string): string {
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+type UnlockedCardProps = { ach: UnlockedAchievement }
+function UnlockedCard({ ach }: UnlockedCardProps) {
+  return (
+    <div style={cardStyle(true)}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ ...iconBadgeStyle, ...tierStyle(ach.tier) }}>{ach.icon}</div>
+        <div>
+          <div style={titleStyle}>{ach.title}</div>
+          <span style={{ ...tierChipStyle, ...tierStyle(ach.tier) }}>{ach.tier}</span>
+        </div>
+      </div>
+      <div style={descStyle}>{ach.description}</div>
+      <div style={metaStyle}>Unlocked {formatDate(ach.unlocked_at)}</div>
+    </div>
+  )
+}
+
+type LockedCardProps = { ach: Achievement }
+function LockedCard({ ach }: LockedCardProps) {
+  return (
+    <div style={cardStyle(false)}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <div style={{ ...iconBadgeStyle, background: '#e5e7eb', color: '#6b7280' }}>🔒</div>
+        <div>
+          <div style={titleStyle}>{ach.title}</div>
+          <span style={{ ...tierChipStyle, background: '#e5e7eb', color: '#6b7280' }}>{ach.tier}</span>
+        </div>
+      </div>
+      <div style={descStyle}>{ach.description}</div>
+    </div>
+  )
+}
+
+export function AchievementsPage() {
+  const { user } = useAuth()
+  const [snap, setSnap] = useState<AchievementsSnapshot | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    try {
+      const data = await api.getMyAchievements()
+      setSnap(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load achievements')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!user) return
+    void reload()
+  }, [user, reload])
+
+  const evaluate = async () => {
+    setBusy(true)
+    setInfo(null)
+    setError(null)
+    try {
+      const res = await api.evaluateMyAchievements()
+      if (res.newly_unlocked.length === 0) {
+        setInfo('No new achievements unlocked.')
+      } else {
+        setInfo(
+          `Unlocked ${res.newly_unlocked.length} achievement${res.newly_unlocked.length === 1 ? '' : 's'}: ${res.newly_unlocked
+            .map((a) => a.title)
+            .join(', ')}`,
+        )
+      }
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to evaluate')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const unlockedCount = snap?.unlocked.length ?? 0
+  const totalCount = (snap?.unlocked.length ?? 0) + (snap?.locked.length ?? 0)
+  const percent = useMemo(() => {
+    if (totalCount === 0) return 0
+    return Math.round((unlockedCount / totalCount) * 100)
+  }, [unlockedCount, totalCount])
+
+  if (!user) {
+    return (
+      <div style={pageStyle}>
+        <h1 style={headerStyle}>Achievements</h1>
+        <div style={subtleStyle}>Sign in to see your achievements.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={pageStyle}>
+      <h1 style={headerStyle}>Achievements</h1>
+      <div style={subtitleStyle}>
+        {unlockedCount} of {totalCount} unlocked ({percent}%).
+      </div>
+
+      <div style={toolbarStyle}>
+        <button style={primaryButtonStyle} onClick={evaluate} disabled={busy || loading}>
+          {busy ? 'Evaluating…' : 'Re-evaluate'}
+        </button>
+        <span style={subtleStyle}>
+          Re-evaluation recomputes your achievement set from your current scoreboard stats. It is safe to run anytime.
+        </span>
+      </div>
+
+      {error && <div style={errorStyle}>{error}</div>}
+      {info && <div style={okStyle}>{info}</div>}
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>Unlocked</div>
+        {loading ? (
+          <div style={subtleStyle}>Loading…</div>
+        ) : unlockedCount === 0 ? (
+          <div style={subtleStyle}>No achievements unlocked yet — play some games!</div>
+        ) : (
+          <div style={gridStyle}>
+            {snap!.unlocked.map((a) => (
+              <UnlockedCard key={a.id} ach={a} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>Locked</div>
+        {loading ? (
+          <div style={subtleStyle}>Loading…</div>
+        ) : (snap?.locked.length ?? 0) === 0 ? (
+          <div style={subtleStyle}>You've unlocked everything. Nicely done!</div>
+        ) : (
+          <div style={gridStyle}>
+            {snap!.locked.map((a) => (
+              <LockedCard key={a.id} ach={a} />
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/FriendsPage.tsx
+++ b/frontend/src/pages/FriendsPage.tsx
@@ -1,0 +1,346 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+import { api } from '../api/client'
+import type { FriendRequestView, FriendSummary, FriendsListResponse } from '../api/types'
+import { useAuth } from '../auth/auth'
+
+// FriendsPage renders three sections — accepted friends, incoming requests,
+// outgoing requests — plus a block list. It calls the backend friends API and
+// optimistically updates local state on common mutations.
+
+const pageStyle: CSSProperties = { padding: '24px', maxWidth: 880, margin: '0 auto' }
+const headerStyle: CSSProperties = { fontSize: 28, fontWeight: 800, margin: '0 0 24px 0' }
+const sectionStyle: CSSProperties = {
+  background: '#fff',
+  border: '1px solid #e5e7eb',
+  borderRadius: 12,
+  padding: 20,
+  marginBottom: 20,
+  boxShadow: '0 1px 2px rgba(0,0,0,0.04)',
+}
+const sectionTitleStyle: CSSProperties = { fontSize: 18, fontWeight: 700, marginBottom: 12 }
+const rowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 12,
+  padding: '10px 8px',
+  borderBottom: '1px solid #f3f4f6',
+}
+const lastRowStyle: CSSProperties = { ...rowStyle, borderBottom: 'none' }
+const avatarStyle: CSSProperties = {
+  width: 36,
+  height: 36,
+  borderRadius: '50%',
+  background: '#e5e7eb',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontWeight: 700,
+  color: '#374151',
+}
+const nameStyle: CSSProperties = { flex: 1, fontWeight: 600 }
+const subtleStyle: CSSProperties = { color: '#6b7280', fontSize: 13 }
+const dangerButtonStyle: CSSProperties = {
+  padding: '6px 12px',
+  background: '#fee2e2',
+  color: '#991b1b',
+  border: '1px solid #fecaca',
+  borderRadius: 6,
+  cursor: 'pointer',
+}
+const primaryButtonStyle: CSSProperties = {
+  padding: '6px 12px',
+  background: '#4a9eff',
+  color: '#fff',
+  border: 'none',
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontWeight: 600,
+}
+const ghostButtonStyle: CSSProperties = {
+  padding: '6px 12px',
+  background: 'transparent',
+  color: '#374151',
+  border: '1px solid #d1d5db',
+  borderRadius: 6,
+  cursor: 'pointer',
+}
+const formRowStyle: CSSProperties = { display: 'flex', gap: 8, marginTop: 12 }
+const inputStyle: CSSProperties = {
+  flex: 1,
+  padding: '8px 12px',
+  border: '1px solid #d1d5db',
+  borderRadius: 6,
+  fontSize: 14,
+}
+const errorStyle: CSSProperties = { color: '#b91c1c', marginTop: 8, fontSize: 14 }
+const okStyle: CSSProperties = { color: '#047857', marginTop: 8, fontSize: 14 }
+
+function initials(name: string): string {
+  const parts = name.trim().split(/\s+/).slice(0, 2)
+  return parts.map((p) => p[0]?.toUpperCase() ?? '').join('') || '?'
+}
+
+function formatDate(ts: string): string {
+  const d = new Date(ts)
+  if (Number.isNaN(d.getTime())) return ts
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+export function FriendsPage() {
+  const { user } = useAuth()
+  const [data, setData] = useState<FriendsListResponse | null>(null)
+  const [blocked, setBlocked] = useState<FriendSummary[]>([])
+  const [loading, setLoading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [info, setInfo] = useState<string | null>(null)
+  const [requestUserId, setRequestUserId] = useState('')
+
+  const reload = useCallback(async () => {
+    setLoading(true)
+    try {
+      const [list, blockedList] = await Promise.all([api.listFriends(), api.listBlocked()])
+      setData(list)
+      setBlocked(blockedList.blocked)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to load friends')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!user) return
+    void reload()
+  }, [user, reload])
+
+  const sendRequest = async () => {
+    const id = Number.parseInt(requestUserId, 10)
+    if (!Number.isFinite(id) || id <= 0) {
+      setError('Enter a valid user id')
+      return
+    }
+    setBusy(true)
+    setError(null)
+    setInfo(null)
+    try {
+      await api.sendFriendRequest(id)
+      setInfo('Request sent')
+      setRequestUserId('')
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to send request')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const accept = async (req: FriendRequestView) => {
+    setBusy(true)
+    try {
+      await api.acceptFriendRequest(req.id)
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to accept')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const decline = async (req: FriendRequestView) => {
+    setBusy(true)
+    try {
+      await api.declineFriendRequest(req.id)
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to decline')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const remove = async (friend: FriendSummary) => {
+    if (!window.confirm(`Remove ${friend.username} from your friends?`)) return
+    setBusy(true)
+    try {
+      await api.removeFriend(friend.user_id)
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to remove')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const block = async (friend: FriendSummary) => {
+    if (!window.confirm(`Block ${friend.username}? This also removes any friendship.`)) return
+    setBusy(true)
+    try {
+      await api.blockUser(friend.user_id)
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to block')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const unblock = async (entry: FriendSummary) => {
+    setBusy(true)
+    try {
+      await api.unblockUser(entry.user_id)
+      await reload()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'failed to unblock')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const friends = data?.friends ?? []
+  const incoming = data?.incoming ?? []
+  const outgoing = data?.outgoing ?? []
+
+  const counts = useMemo(
+    () => ({ friends: friends.length, incoming: incoming.length, outgoing: outgoing.length, blocked: blocked.length }),
+    [friends.length, incoming.length, outgoing.length, blocked.length],
+  )
+
+  if (!user) {
+    return (
+      <div style={pageStyle}>
+        <h1 style={headerStyle}>Friends</h1>
+        <div style={subtleStyle}>Sign in to manage your friends list.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div style={pageStyle}>
+      <h1 style={headerStyle}>Friends</h1>
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>Send a Friend Request</div>
+        <div style={subtleStyle}>Enter another player's user id to send them a request.</div>
+        <div style={formRowStyle}>
+          <input
+            style={inputStyle}
+            type="number"
+            min={1}
+            placeholder="User id"
+            value={requestUserId}
+            onChange={(e) => setRequestUserId(e.target.value)}
+            disabled={busy}
+          />
+          <button style={primaryButtonStyle} onClick={sendRequest} disabled={busy || !requestUserId.trim()}>
+            Send
+          </button>
+        </div>
+        {error && <div style={errorStyle}>{error}</div>}
+        {info && <div style={okStyle}>{info}</div>}
+      </section>
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>
+          Incoming requests {counts.incoming > 0 && <span style={subtleStyle}>({counts.incoming})</span>}
+        </div>
+        {loading ? (
+          <div style={subtleStyle}>Loading…</div>
+        ) : incoming.length === 0 ? (
+          <div style={subtleStyle}>No incoming requests.</div>
+        ) : (
+          incoming.map((req, idx) => (
+            <div key={req.id} style={idx === incoming.length - 1 ? lastRowStyle : rowStyle}>
+              <div style={avatarStyle}>{initials(req.from_username)}</div>
+              <div style={nameStyle}>
+                {req.from_username}
+                <div style={subtleStyle}>Sent {formatDate(req.created_at)}</div>
+              </div>
+              <button style={primaryButtonStyle} onClick={() => accept(req)} disabled={busy}>
+                Accept
+              </button>
+              <button style={ghostButtonStyle} onClick={() => decline(req)} disabled={busy}>
+                Decline
+              </button>
+            </div>
+          ))
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>
+          Outgoing requests {counts.outgoing > 0 && <span style={subtleStyle}>({counts.outgoing})</span>}
+        </div>
+        {loading ? (
+          <div style={subtleStyle}>Loading…</div>
+        ) : outgoing.length === 0 ? (
+          <div style={subtleStyle}>No outgoing requests.</div>
+        ) : (
+          outgoing.map((req, idx) => (
+            <div key={req.id} style={idx === outgoing.length - 1 ? lastRowStyle : rowStyle}>
+              <div style={avatarStyle}>{initials(req.from_username)}</div>
+              <div style={nameStyle}>
+                {req.from_username}
+                <div style={subtleStyle}>Sent {formatDate(req.created_at)}</div>
+              </div>
+              <span style={subtleStyle}>Pending</span>
+            </div>
+          ))
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>
+          Friends {counts.friends > 0 && <span style={subtleStyle}>({counts.friends})</span>}
+        </div>
+        {loading ? (
+          <div style={subtleStyle}>Loading…</div>
+        ) : friends.length === 0 ? (
+          <div style={subtleStyle}>No friends yet. Send a request above to get started.</div>
+        ) : (
+          friends.map((friend, idx) => (
+            <div key={friend.user_id} style={idx === friends.length - 1 ? lastRowStyle : rowStyle}>
+              <div style={avatarStyle}>{initials(friend.username)}</div>
+              <div style={nameStyle}>
+                {friend.username}
+                <div style={subtleStyle}>Friends since {formatDate(friend.since)}</div>
+              </div>
+              <button style={ghostButtonStyle} onClick={() => remove(friend)} disabled={busy}>
+                Remove
+              </button>
+              <button style={dangerButtonStyle} onClick={() => block(friend)} disabled={busy}>
+                Block
+              </button>
+            </div>
+          ))
+        )}
+      </section>
+
+      <section style={sectionStyle}>
+        <div style={sectionTitleStyle}>
+          Blocked {counts.blocked > 0 && <span style={subtleStyle}>({counts.blocked})</span>}
+        </div>
+        {loading ? (
+          <div style={subtleStyle}>Loading…</div>
+        ) : blocked.length === 0 ? (
+          <div style={subtleStyle}>No blocked users.</div>
+        ) : (
+          blocked.map((entry, idx) => (
+            <div key={entry.user_id} style={idx === blocked.length - 1 ? lastRowStyle : rowStyle}>
+              <div style={avatarStyle}>{initials(entry.username)}</div>
+              <div style={nameStyle}>
+                {entry.username}
+                <div style={subtleStyle}>Blocked {formatDate(entry.since)}</div>
+              </div>
+              <button style={ghostButtonStyle} onClick={() => unblock(entry)} disabled={busy}>
+                Unblock
+              </button>
+            </div>
+          ))
+        )}
+      </section>
+    </div>
+  )
+}

--- a/frontend/src/pages/GamePage.tsx
+++ b/frontend/src/pages/GamePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { api } from '../api/client'
 import type { Card, GameMove, GameSnapshot, UserStats } from '../api/types'
@@ -10,6 +10,13 @@ import type React from 'react'
 const CARD_W = 70
 const CARD_H = 98
 const CARD_R = 12
+
+// Hoisted static style objects. Inline literals in JSX allocate every render and
+// break referential equality for memoised children.
+const scoreBreakdownNoneStyle: React.CSSProperties = { opacity: 0.8 }
+const scoreBreakdownWrapperStyle: React.CSSProperties = { opacity: 0.92 }
+const scoreBreakdownTotalStyle: React.CSSProperties = { fontWeight: 900 }
+const scoreBreakdownPartsStyle: React.CSSProperties = { opacity: 0.9 }
 
 type ScoreBreakdown = {
   total: number
@@ -27,24 +34,42 @@ type PlayerProfileState = {
   error?: string
 }
 
-function ScoreBreakdownLine({ b }: { b: ScoreBreakdown | undefined }) {
-  if (!b) return <span style={{ opacity: 0.8 }}>(no breakdown)</span>
-  const parts: Array<[string, number]> = (
-    [
-      ['15s', b.fifteens],
-      ['pairs', b.pairs],
-      ['runs', b.runs],
-      ['flush', b.flush],
-      ['nobs', b.nobs],
-    ] as Array<[string, number]>
-  ).filter(([, v]) => v > 0)
-  return (
-    <span style={{ opacity: 0.92 }}>
-      <span style={{ fontWeight: 900 }}>+{b.total}</span>
-      {parts.length > 0 ? <span style={{ opacity: 0.9 }}> ({parts.map(([k, v]) => `${k} ${v}`).join(' · ')})</span> : null}
-    </span>
-  )
-}
+const ScoreBreakdownLine = memo(
+  function ScoreBreakdownLine({ b }: { b: ScoreBreakdown | undefined }) {
+    if (!b) return <span style={scoreBreakdownNoneStyle}>(no breakdown)</span>
+    const parts: Array<[string, number]> = (
+      [
+        ['15s', b.fifteens],
+        ['pairs', b.pairs],
+        ['runs', b.runs],
+        ['flush', b.flush],
+        ['nobs', b.nobs],
+      ] as Array<[string, number]>
+    ).filter(([, v]) => v > 0)
+    return (
+      <span style={scoreBreakdownWrapperStyle}>
+        <span style={scoreBreakdownTotalStyle}>+{b.total}</span>
+        {parts.length > 0 ? <span style={scoreBreakdownPartsStyle}> ({parts.map(([k, v]) => `${k} ${v}`).join(' · ')})</span> : null}
+      </span>
+    )
+  },
+  // Custom comparator: parent rebuilds the breakdown object each render, so
+  // referential equality is useless. Compare the fields that affect output.
+  (prev, next) => {
+    const a = prev.b
+    const b = next.b
+    if (a === b) return true
+    if (!a || !b) return false
+    return (
+      a.total === b.total &&
+      a.fifteens === b.fifteens &&
+      a.pairs === b.pairs &&
+      a.runs === b.runs &&
+      a.flush === b.flush &&
+      a.nobs === b.nobs
+    )
+  },
+)
 
 function playerInitials(name: string): string {
   const trimmed = name.trim()
@@ -64,25 +89,25 @@ function profilePalette(slot: number) {
   return palettes[Math.abs(slot) % palettes.length]
 }
 
-function PlayerProfileCard({
-  player,
-  profile,
-  isDealer,
-  isYou,
-}: {
+type PlayerProfileCardProps = {
   player: GameSnapshot['players'][number]
   profile: PlayerProfileState | undefined
   isDealer: boolean
   isYou: boolean
-}) {
-  const palette = profilePalette(player.position)
+}
+
+function PlayerProfileCardImpl({ player, profile, isDealer, isYou }: PlayerProfileCardProps) {
+  const palette = useMemo(() => profilePalette(player.position), [player.position])
   const stats = profile?.stats
-  const gamesPlayed = stats?.games_played ?? 0
-  const wins = stats?.games_won ?? 0
-  const losses = Math.max(0, gamesPlayed - wins)
-  const winRate = gamesPlayed > 0 ? Math.round((wins / gamesPlayed) * 100) : null
-  const rank =
-    gamesPlayed >= 20 ? (winRate !== null && winRate >= 60 ? 'Ace' : winRate !== null && winRate >= 45 ? 'Pro' : 'Regular') : 'Rookie'
+  const { gamesPlayed, wins, losses, winRate, rank } = useMemo(() => {
+    const gp = stats?.games_played ?? 0
+    const w = stats?.games_won ?? 0
+    const l = Math.max(0, gp - w)
+    const wr = gp > 0 ? Math.round((w / gp) * 100) : null
+    const r =
+      gp >= 20 ? (wr !== null && wr >= 60 ? 'Ace' : wr !== null && wr >= 45 ? 'Pro' : 'Regular') : 'Rookie'
+    return { gamesPlayed: gp, wins: w, losses: l, winRate: wr, rank: r }
+  }, [stats?.games_played, stats?.games_won])
 
   return (
     <div
@@ -220,6 +245,27 @@ function PlayerProfileCard({
     </div>
   )
 }
+
+const PlayerProfileCard = memo(PlayerProfileCardImpl, (prev, next) => {
+  // Parent rebuilds profile objects on each WS update; compare by content.
+  if (prev.isDealer !== next.isDealer || prev.isYou !== next.isYou) return false
+  if (prev.player !== next.player) {
+    // Player object may be rebuilt — compare displayed fields.
+    if (
+      prev.player.user_id !== next.player.user_id ||
+      prev.player.position !== next.player.position ||
+      prev.player.username !== next.player.username
+    ) {
+      return false
+    }
+  }
+  const a = prev.profile
+  const b = next.profile
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.loading !== b.loading || a.error !== b.error) return false
+  return a.stats?.games_played === b.stats?.games_played && a.stats?.games_won === b.stats?.games_won
+})
 
 function rankLabel(rank: number): string {
   return rank === 1 ? 'A' : rank === 11 ? 'J' : rank === 12 ? 'Q' : rank === 13 ? 'K' : String(rank)
@@ -695,17 +741,27 @@ export function GamePage() {
     void fetchSnapshot()
     void fetchMoves()
 
+    // Coalesce bursts of game_update events. A flurry of broadcasts during e.g. round
+    // transitions would otherwise fire one HTTP round-trip per event.
+    let refetchTimer: ReturnType<typeof setTimeout> | null = null
+    const scheduleRefetch = () => {
+      if (refetchTimer !== null) return
+      refetchTimer = setTimeout(() => {
+        refetchTimer = null
+        void fetchSnapshot()
+        void fetchMoves()
+      }, 75)
+    }
+
     ws.connect(`game:${gameId}`)
     const offOpen = ws.on('ws_open', () => setStatus('connected'))
     const offClose = ws.on('ws_close', () => setStatus('disconnected'))
     // WS broadcasts a public snapshot (hands hidden). Treat updates as an invalidation signal
     // and re-fetch the user-specific snapshot via HTTP so "your hand" stays populated.
-    const offUpdate = ws.on('game_update', () => {
-      void fetchSnapshot()
-      void fetchMoves()
-    })
+    const offUpdate = ws.on('game_update', scheduleRefetch)
     return () => {
       cancelled = true
+      if (refetchTimer !== null) clearTimeout(refetchTimer)
       offOpen()
       offClose()
       offUpdate()

--- a/frontend/src/pages/LobbiesPage.tsx
+++ b/frontend/src/pages/LobbiesPage.tsx
@@ -84,6 +84,8 @@ export function LobbiesPage() {
           <div style={{ display: 'flex', gap: 12, alignItems: 'baseline' }}>
             <Link to="/lobbies/new">Create</Link>
             <Link to="/leaderboard">Leaderboard</Link>
+            <Link to="/friends">Friends</Link>
+            <Link to="/achievements">Achievements</Link>
             <button onClick={playVsBot} disabled={quickBusy} title="Create a 2-player lobby and add a bot">
               {quickBusy ? 'Starting…' : 'Play vs Computer'}
             </button>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk Score: Medium - Human Review Required

## Summary
Languages & frameworks: Go (Gin, database/sql, websocket hub), TypeScript + React (Vite/React). Code patterns: MVC-style handlers/models, middleware token-bucket rate limiter, idempotent schema bootstrapping, WebSocket pub/sub, memoized React components, debounced WS refetch. Brief: Refactors backend for performance, adds friends/achievements/chat-reactions/rate-limiting and matching frontend pages/types/API client in unbuilt draft form.

## Major Changes

- Backend infrastructure
  - In-memory per-key token-bucket limiter with GC, introspection, X-RateLimit headers, and Gin middleware; distinct limits wired for auth vs protected groups.
  - Startup schema bootstrapping (friends, achievements, message reactions) and new import of internal/models in cmd/server/main.go.
  - WebSocket Hub: larger broadcast buffer (1024), short blocking retry (≤50ms), dropped-broadcast accounting and conditional logging.

- Social & progression features
  - Friends: full persistence + handlers (send/accept/decline requests; list incoming/outgoing/friends; remove; block/unblock; list blocked; AreFriends), schema and sentinel errors.
  - Achievements: compile-time catalogue, evaluation logic (wins, plays, win-rate, hour-window achievements), transactional persistence/upserts, listing and evaluate endpoints.
  - Chat reactions: emoji allow-list, per-message ReactionView (count, user IDs, reacted flag), toggle and GET rollup endpoints, DB uniqueness/indexes, WS rollup broadcasts.

- Web & client
  - New React pages: FriendsPage and AchievementsPage; routes added under RequireAuth.
  - API client: centralized required<T>() and url(), ~14 new endpoints for friends/achievements/reactions; TS types added for these models.
  - LobbyChat/GamePage: hoisted static styles, memoized components with custom comparators, 75ms debounce/coalescing for WS-triggered refetches.
  - LobbiesPage header links updated to include Friends and Achievements.

- Performance & hygiene
  - Leaderboard and ListLobbies pre-sized slices, loop-hoisting, reduced per-iteration cancellation checks.
  - Lobby helpers: getUsername/getUserDisplay/isActiveLobbyMember to remove duplicated SQL and standardize lobbyRoomKey.

## Caveats & Review Notes (actionable)
- Branch contains many new files and frontend code hasn't been built/type-checked—treat as draft; run full go build/test and front-end type checks.
- Possible Gin route param overlap for /api/users/:id/achievements — verify routing order and path conflicts.
- cmd/server/main.go now imports internal/models—confirm module boundaries and dependency impacts.
- Rate limiter Stop ordering and lifecycle: verify server shutdown ordering to avoid GC goroutine leaks.
- Schema creation is idempotent but validate against production migrations/backups before rollout.
- Frontend memo comparators are conservative; review to avoid stale UI when adding visible fields.
- Emoji normalization/UX: confirm whitelist and locale/normalization requirements.

## Testing priorities
- Friends: edge cases (self-request, mutual blocks, re-request after decline), concurrency and transaction consistency.
- Achievements: evaluation correctness across win/play counts, win-rate thresholds, and hour-window edge cases (UTC).
- Rate limiter: behavior under load, keying correctness (user vs IP), headers (behind proxies), and GC/Stop behavior.
- WebSocket hub: verify rollup broadcasts, dropped-broadcast counts, brief enqueue wait behavior, and graceful shutdown.
- Frontend: API error paths, optimistic updates, memoization correctness, and build/type-check pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iantybo/fifteen-thirty-one-go/pull/95)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->