### PR TITLE
refactor: replace magic literals with named constants

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 func main() {
-	cfg, err := config.LoadFromEnv()
+	cfg err := config.LoadFromEnv()
 	if err != nil {
 		log.Fatalf("config: %v", err)
 	}

--- a/uservices/services/astros/main.go
+++ b/uservices/services/astros/main.go
@@ -47,6 +47,7 @@ func score(hand cribbage.Hand) cribbage.ScoreBreakdown {
 	for _, c := range cards {
 		counts[c.Rank]++
 	}
+	const minRunLength = 3
 	bestLen, bestMult := 0, 0
 	for start := 1; start <= 13; start++ {
 		length, mult := 0, 1
@@ -58,7 +59,7 @@ func score(hand cribbage.Hand) cribbage.ScoreBreakdown {
 			length++
 			mult *= n
 		}
-		if length >= 3 && length > bestLen {
+		if length >= minRunLength && length > bestLen {
 			bestLen, bestMult = length, mult
 		}
 	}

--- a/uservices/services/basil/main.go
+++ b/uservices/services/basil/main.go
@@ -14,10 +14,13 @@ import (
 
 const serviceName = "basil"
 
+// listenAddr is the address the service binds to.
+const listenAddr = ":8080"
+
 func main() {
 	svc := service.New(serviceName)
 	svc.Handle("/score", handleScore(svc))
-	if err := svc.ListenAndServe(":8080"); err != nil {
+	if err := svc.ListenAndServe(listenAddr); err != nil {
 		panic(err)
 	}
 }

--- a/uservices/services/bordeaux/main.go
+++ b/uservices/services/bordeaux/main.go
@@ -38,8 +38,9 @@ func handleScore(svc *service.Service) http.HandlerFunc {
 		ctx, cancel := service.RequestContext(r.Context())
 		defer cancel()
 
+		const downstream = "ivy"
 		var bd cribbage.ScoreBreakdown
-		if err := svc.Mesh.Call(ctx, "ivy", "/score", hand, &bd); err != nil {
+		if err := svc.Mesh.Call(ctx, downstream, "/score", hand, &bd); err != nil {
 			service.WriteJSON(w, http.StatusBadGateway, map[string]string{"error": err.Error()})
 			return
 		}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Risk Score: High - Escalation Required

**High-Level Summary**

Go services using Gin and OpenTelemetry. This refactor replaces inline “magic literals” with named constants for scoring thresholds and service wiring (listen address, downstream target), plus a configuration-load change in server startup. One edit appears to introduce invalid Go syntax (`cfg err := ...`), requiring human review/build verification.

**Changes Overview**

- `uservices/services/astros/main.go`: Extracted `minRunLength` constant (was `3`) and used it in the run-scoring eligibility check.
- `uservices/services/basil/main.go`: Added `listenAddr` constant and passed it to `svc.ListenAndServe` (replacing inline `":8080"`).
- `uservices/services/bordeaux/main.go`: Introduced local `downstream` constant (`"ivy"`) used as the mesh call target (replacing inline `"ivy"`).
- `backend/cmd/server/main.go`: Changed config load assignment to `cfg err := config.LoadFromEnv()` (appears syntactically incorrect; should be `cfg, err := ...`), risking compilation failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->