### PR TITLE
chore: add TypeScript file pattern for FRONTEND.md guidelines

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -32,6 +32,8 @@ knowledge_base:
       - docs/FRONTEND-DESIGN-GUIDE.md
       - docs/infosec/SECURITY-*.md
       - agents/*AGENT*.md
+      - files: FRONTEND.md
+        applyTo: "**/*.ts"
   web_search:
     enabled: true
   learnings:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Risk Score: Extremely Low - Auto-merge

Languages/frameworks/code patterns: YAML configuration for CodeRabbit review rules; no application code or framework changes.

Added a `.coderabbit.yml` file-pattern rule so `FRONTEND.md` guidance applies to TypeScript files (`**/*.ts`). This updates AI review context without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->